### PR TITLE
Update headers on create video

### DIFF
--- a/src/Enum/Stream/VideoEndpoint.php
+++ b/src/Enum/Stream/VideoEndpoint.php
@@ -113,6 +113,7 @@ final class VideoEndpoint
         'path' => 'library/%d/videos',
         'headers' => [
             Header::ACCEPT_JSON,
+            Header::CONTENT_TYPE_JSON_ALL,
         ],
         'query' => [],
         'body' => [


### PR DESCRIPTION
This is to address #28. However should all POST endpoints have this header included to be accepted by BunnyCDN, and should this be across all endpoint stores such as collection, or even the edge storage?