### PR TITLE
stream video library - add search key

### DIFF
--- a/docs/base-api.md
+++ b/docs/base-api.md
@@ -499,10 +499,15 @@ $baseApi->listVideoLibraries(
     query: [
         'page' => 0,
         'perPage' => 1000,
+        'search' => 'bunny',
         'includeAccessKey' => false,
     ],
 );
 ```
+
+!!! note
+
+    - The key `search` is currently not functional.
 
 #### [Add Video Library](https://docs.bunny.net/reference/videolibrarypublic_add)
 
@@ -589,6 +594,10 @@ $baseApi->updateVideoLibrary(
         'ShowHeatmap' => false,
         'EnableContentTagging' => true,
         'FontFamily' => 'Arial',
+        'EnableTranscribing' => false,
+        'EnableTranscribingTitleGeneration' => false,
+        'EnableTranscribingDescriptionGeneration' => false,
+        'TranscribingCaptionLanguages' => [],
     ],
 );
 ```
@@ -615,6 +624,7 @@ $baseApi->updateVideoLibrary(
         - `pip`
         - `airplay`
         - `fullscreen`
+    - To get a full list of possible value options for key `TranscribingCaptionLanguages`, see the [Get Languages](#get-languages) endpoint.
 
 #### [Delete Video Library](https://docs.bunny.net/reference/videolibrarypublic_delete)
 

--- a/src/Model/API/Base/StreamVideoLibrary/ListVideoLibraries.php
+++ b/src/Model/API/Base/StreamVideoLibrary/ListVideoLibraries.php
@@ -35,6 +35,7 @@ class ListVideoLibraries implements EndpointInterface, EndpointQueryInterface
         return [
             new AbstractParameter(name: 'page', type: Type::INT_TYPE),
             new AbstractParameter(name: 'perPage', type: Type::INT_TYPE),
+            new AbstractParameter(name: 'search', type: Type::STRING_TYPE),
             new AbstractParameter(name: 'includeAccessKey', type: Type::BOOLEAN_TYPE),
         ];
     }

--- a/src/Model/API/Base/StreamVideoLibrary/UpdateVideoLibrary.php
+++ b/src/Model/API/Base/StreamVideoLibrary/UpdateVideoLibrary.php
@@ -69,6 +69,12 @@ class UpdateVideoLibrary implements EndpointInterface, EndpointBodyInterface
             new AbstractParameter(name: 'ShowHeatmap', type: Type::BOOLEAN_TYPE),
             new AbstractParameter(name: 'EnableContentTagging', type: Type::BOOLEAN_TYPE),
             new AbstractParameter(name: 'FontFamily', type: Type::STRING_TYPE),
+            new AbstractParameter(name: 'EnableTranscribing', type: Type::BOOLEAN_TYPE),
+            new AbstractParameter(name: 'EnableTranscribingTitleGeneration', type: Type::BOOLEAN_TYPE),
+            new AbstractParameter(name: 'EnableTranscribingDescriptionGeneration', type: Type::BOOLEAN_TYPE),
+            new AbstractParameter(name: 'TranscribingCaptionLanguages', type: Type::ARRAY_TYPE, children: [
+                new AbstractParameter(name: null, type: Type::STRING_TYPE),
+            ]),
         ];
     }
 }


### PR DESCRIPTION
Fixes #81 

> Note: while the `search` key is not functional at this moment, it was added to be conform the official API specs.