### PR TITLE
storage zone - list storage zone search key

### DIFF
--- a/docs/base-api.md
+++ b/docs/base-api.md
@@ -1748,10 +1748,15 @@ $baseApi->listStorageZones(
     query: [
         'page' => 0,
         'perPage' => 1000,
+        'search' => 'bunny',
         'includeDeleted' => 1000,
     ],
 );
 ```
+
+!!! note
+
+    - The key `search` is currently not functional.
 
 #### [Add Storage Zone](https://docs.bunny.net/reference/storagezonepublic_add)
 

--- a/src/Model/API/Base/StorageZone/ListStorageZones.php
+++ b/src/Model/API/Base/StorageZone/ListStorageZones.php
@@ -35,6 +35,7 @@ class ListStorageZones implements EndpointInterface, EndpointQueryInterface
         return [
             new AbstractParameter(name: 'page', type: Type::INT_TYPE),
             new AbstractParameter(name: 'perPage', type: Type::INT_TYPE),
+            new AbstractParameter(name: 'search', type: Type::STRING_TYPE),
             new AbstractParameter(name: 'includeDeleted', type: Type::BOOLEAN_TYPE),
         ];
     }


### PR DESCRIPTION
Fixes #84 

> Note: while the `search` key is not functional at this moment, it was added to be conform the official API specs.