### PR TITLE
removing %d because adding video libraries doesn't require it.

### DIFF
--- a/src/Model/API/Base/StreamVideoLibrary/AddVideoLibrary.php
+++ b/src/Model/API/Base/StreamVideoLibrary/AddVideoLibrary.php
@@ -20,7 +20,7 @@ class AddVideoLibrary implements EndpointInterface, EndpointBodyInterface
 
     public function getPath(): string
     {
-        return 'videolibrary/%d';
+        return 'videolibrary';
     }
 
     public function getHeaders(): array


### PR DESCRIPTION
Adding video library doesn't require %d to work ,