### PR TITLE
Fix headers for UpdateVideoLibrary endpoint

### DIFF
--- a/src/Model/API/Base/StreamVideoLibrary/UpdateVideoLibrary.php
+++ b/src/Model/API/Base/StreamVideoLibrary/UpdateVideoLibrary.php
@@ -27,6 +27,7 @@ class UpdateVideoLibrary implements EndpointInterface, EndpointBodyInterface
     {
         return [
             Header::ACCEPT_JSON,
+            Header::CONTENT_TYPE_JSON,
         ];
     }
 


### PR DESCRIPTION
Thanks for creating this SDK!

I noticed that the `Content-Type` header was missing in the request to update a video library. That missing header leads to Bunny.net silently ignoring the request body.