### PR TITLE
SetForceSSL Hostname parameter expects to be string not int

### DIFF
--- a/src/Model/API/Base/PullZone/SetForceSSL.php
+++ b/src/Model/API/Base/PullZone/SetForceSSL.php
@@ -34,7 +34,7 @@ class SetForceSSL implements EndpointInterface, EndpointBodyInterface
     public function getBody(): array
     {
         return [
-            new AbstractParameter(name: 'Hostname', type: Type::INT_TYPE, required: true),
+            new AbstractParameter(name: 'Hostname', type: Type::STRING_TYPE, required: true),
             new AbstractParameter(name: 'ForceSSL', type: Type::BOOLEAN_TYPE, required: true),
         ];
     }


### PR DESCRIPTION
Hiya. Found a small bug while exploring some automation using the Bunny api.

The Bunny SetForceSSL endpoint expects the Hostname parameter to be string, while the `\ToshY\BunnyNet\Model\API\Base\PullZone\SetForceSSL` class defines this parameter as int.

Simply changed the definition to string, this fixes the issue.