### PR TITLE
Add BunnyValidator for more flexible validation

### DIFF
--- a/phpmd.baseline.xml
+++ b/phpmd.baseline.xml
@@ -18,7 +18,7 @@
   <violation rule="PHPMD\Rule\Design\CouplingBetweenObjects" file="src/StreamAPI.php"/>
   <violation rule="PHPMD\Rule\Design\LongParameterList" file="src/TokenAuthentication.php" method="sign"/>
   <violation rule="PHPMD\Rule\CleanCode\BooleanArgumentFlag" file="src/TokenAuthentication.php"/>
-  <violation rule="PHPMD\Rule\CyclomaticComplexity" file="src/Validator/ParameterValidator.php" method="validate"/>
-  <violation rule="PHPMD\Rule\Design\NpathComplexity" file="src/Validator/ParameterValidator.php" method="validate"/>
-  <violation rule="PHPMD\Rule\Design\LongMethod" file="src/Validator/ParameterValidator.php" method="validate"/>
+  <violation rule="PHPMD\Rule\CyclomaticComplexity" file="src/Validation/ParameterValidator.php" method="validate"/>
+  <violation rule="PHPMD\Rule\Design\NpathComplexity" file="src/Validation/ParameterValidator.php" method="validate"/>
+  <violation rule="PHPMD\Rule\Design\LongMethod" file="src/Validation/ParameterValidator.php" method="validate"/>
 </phpmd-baseline>

--- a/src/BaseAPI.php
+++ b/src/BaseAPI.php
@@ -116,17 +116,19 @@ use ToshY\BunnyNet\Model\API\Base\User\SetNotificationsOpened;
 use ToshY\BunnyNet\Model\API\Base\User\UpdateUserDetails;
 use ToshY\BunnyNet\Model\API\Base\User\VerifyTwoFactorAuthenticationCode;
 use ToshY\BunnyNet\Model\Client\Interface\BunnyClientResponseInterface;
-use ToshY\BunnyNet\Validator\ParameterValidator;
+use ToshY\BunnyNet\Validation\BunnyValidator;
 
 class BaseAPI
 {
     /**
      * @param string $apiKey
      * @param BunnyClient $client
+     * @param BunnyValidator $validator
      */
     public function __construct(
         protected readonly string $apiKey,
         protected readonly BunnyClient $client,
+        protected readonly BunnyValidator $validator = new BunnyValidator(),
     ) {
         $this->client
             ->setApiKey($this->apiKey)
@@ -137,11 +139,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\BunnyClientResponseException
-     * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param array<string,mixed> $query
      * @return BunnyClientResponseInterface
      */
@@ -149,7 +147,7 @@ class BaseAPI
     {
         $endpoint = new ListAbuseCases();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -246,9 +244,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param array<string,mixed> $body
      */
@@ -256,7 +252,7 @@ class BaseAPI
     {
         $endpoint = new AuthJwt2fa();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -297,10 +293,8 @@ class BaseAPI
     /**
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
      * @throws Exception\JSONException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param array<string,mixed> $query
      * @return BunnyClientResponseInterface
      */
@@ -308,7 +302,7 @@ class BaseAPI
     {
         $endpoint = new ListAPIKeys();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -334,9 +328,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param array<string,mixed> $body
      */
@@ -344,7 +336,7 @@ class BaseAPI
     {
         $endpoint = new ConfigureAutoRecharge();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -356,9 +348,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param array<string,mixed> $body
      */
@@ -366,7 +356,7 @@ class BaseAPI
     {
         $endpoint = new CreatePaymentCheckout();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -438,9 +428,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param array<string,mixed> $query
      * @return BunnyClientResponseInterface
      */
@@ -448,7 +436,7 @@ class BaseAPI
     {
         $endpoint = new CreateCoinifyPayment();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -492,9 +480,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param array<string,mixed> $query
      * @return BunnyClientResponseInterface
      */
@@ -502,7 +488,7 @@ class BaseAPI
     {
         $endpoint = new ApplyPromoCode();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -514,9 +500,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param array<string,mixed> $query
      * @return BunnyClientResponseInterface
      */
@@ -524,7 +508,7 @@ class BaseAPI
     {
         $endpoint = new ListTickets();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -570,9 +554,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param int $id
      * @param array<string,mixed> $body
@@ -583,7 +565,7 @@ class BaseAPI
     ): BunnyClientResponseInterface {
         $endpoint = new ReplyTicket();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -597,9 +579,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param array<string,mixed> $body
      */
@@ -607,7 +587,7 @@ class BaseAPI
     {
         $endpoint = new CreateTicket();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -619,9 +599,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param array<string,mixed> $query
      * @return BunnyClientResponseInterface
      */
@@ -629,7 +607,7 @@ class BaseAPI
     {
         $endpoint = new ListDRMCertificates();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -671,9 +649,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param array<string,mixed> $query
      * @return BunnyClientResponseInterface
      */
@@ -681,7 +657,7 @@ class BaseAPI
     {
         $endpoint = new ListVideoLibraries();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -693,9 +669,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param array<string,mixed> $body
      */
@@ -703,7 +677,7 @@ class BaseAPI
     {
         $endpoint = new AddVideoLibrary();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -733,9 +707,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param int $id
      * @param array<string,mixed> $body
@@ -746,7 +718,7 @@ class BaseAPI
     ): BunnyClientResponseInterface {
         $endpoint = new UpdateVideoLibrary();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -791,9 +763,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param array<string,mixed> $query
      * @return BunnyClientResponseInterface
      */
@@ -801,7 +771,7 @@ class BaseAPI
     {
         $endpoint = new Model\API\Base\StreamVideoLibrary\ResetPassword();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -864,9 +834,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param int $id
      * @param array<string,mixed> $body
@@ -877,7 +845,7 @@ class BaseAPI
     ): BunnyClientResponseInterface {
         $endpoint = new Model\API\Base\StreamVideoLibrary\AddAllowedReferer();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -890,9 +858,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param int $id
      * @param array<string,mixed> $body
@@ -903,7 +869,7 @@ class BaseAPI
     ): BunnyClientResponseInterface {
         $endpoint = new Model\API\Base\StreamVideoLibrary\DeleteAllowedReferer();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -916,9 +882,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param int $id
      * @param array<string,mixed> $body
@@ -929,7 +893,7 @@ class BaseAPI
     ): BunnyClientResponseInterface {
         $endpoint = new Model\API\Base\StreamVideoLibrary\AddBlockedReferer();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -942,9 +906,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param int $id
      * @param array<string,mixed> $body
@@ -955,7 +917,7 @@ class BaseAPI
     ): BunnyClientResponseInterface {
         $endpoint = new Model\API\Base\StreamVideoLibrary\DeleteBlockedReferer();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -968,9 +930,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param array<string,mixed> $query
      * @return BunnyClientResponseInterface
      */
@@ -978,7 +938,7 @@ class BaseAPI
     {
         $endpoint = new ListDNSZones();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -990,9 +950,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param array<string,mixed> $body
      */
@@ -1000,7 +958,7 @@ class BaseAPI
     {
         $endpoint = new AddDNSZone();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -1029,9 +987,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param int $id
      * @param array<string,mixed> $body
@@ -1042,7 +998,7 @@ class BaseAPI
     ): BunnyClientResponseInterface {
         $endpoint = new UpdateDNSZone();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -1123,9 +1079,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param array<string,mixed> $query
      * @return BunnyClientResponseInterface
      * @param int $id
@@ -1136,7 +1090,7 @@ class BaseAPI
     ): BunnyClientResponseInterface {
         $endpoint = new GetDNSZoneQueryStatistics();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -1149,9 +1103,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param array<string,mixed> $body
      */
@@ -1159,7 +1111,7 @@ class BaseAPI
     {
         $endpoint = new CheckDNSZoneAvailability();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -1171,9 +1123,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param int $zoneId
      * @param array<string,mixed> $body
@@ -1184,7 +1134,7 @@ class BaseAPI
     ): BunnyClientResponseInterface {
         $endpoint = new AddDNSRecord();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -1197,9 +1147,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param int $id
      * @param array<string,mixed> $body
      * @return BunnyClientResponseInterface
@@ -1212,7 +1160,7 @@ class BaseAPI
     ): BunnyClientResponseInterface {
         $endpoint = new UpdateDNSRecord();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -1300,9 +1248,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param array<string,mixed> $query
      * @return BunnyClientResponseInterface
      */
@@ -1310,7 +1256,7 @@ class BaseAPI
     {
         $endpoint = new ListPullZones();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -1322,9 +1268,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param array<string,mixed> $body
      */
@@ -1332,7 +1276,7 @@ class BaseAPI
     {
         $endpoint = new AddPullZone();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -1344,9 +1288,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param array<string,mixed> $query
      * @return BunnyClientResponseInterface
      * @param int $id
@@ -1357,7 +1299,7 @@ class BaseAPI
     ): BunnyClientResponseInterface {
         $endpoint = new GetPullZone();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -1370,9 +1312,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param int $id
      * @param array<string,mixed> $body
@@ -1383,7 +1323,7 @@ class BaseAPI
     ): BunnyClientResponseInterface {
         $endpoint = new UpdatePullZone();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -1433,9 +1373,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param int $pullZoneId
      * @param array<string,mixed> $body
@@ -1446,7 +1384,7 @@ class BaseAPI
     ): BunnyClientResponseInterface {
         $endpoint = new AddOrUpdateEdgeRule();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -1459,9 +1397,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param string $edgeRuleId
      * @param array<string,mixed> $body
      * @return BunnyClientResponseInterface
@@ -1474,7 +1410,7 @@ class BaseAPI
     ): BunnyClientResponseInterface {
         $endpoint = new SetEdgeRuleEnabled();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -1527,9 +1463,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param array<string,mixed> $query
      * @return BunnyClientResponseInterface
      * @param int $pullZoneId
@@ -1540,7 +1474,7 @@ class BaseAPI
     ): BunnyClientResponseInterface {
         $endpoint = new GetOriginShieldQueueStatistics();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -1553,9 +1487,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param array<string,mixed> $query
      * @return BunnyClientResponseInterface
      * @param int $pullZoneId
@@ -1566,7 +1498,7 @@ class BaseAPI
     ): BunnyClientResponseInterface {
         $endpoint = new GetSafeHopStatistics();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -1579,9 +1511,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param array<string,mixed> $query
      * @return BunnyClientResponseInterface
      * @param int $pullZoneId
@@ -1592,7 +1522,7 @@ class BaseAPI
     ): BunnyClientResponseInterface {
         $endpoint = new GetOptimizerStatistics();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -1605,9 +1535,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param array<string,mixed> $query
      * @return BunnyClientResponseInterface
      * @param int $pullZoneId
@@ -1618,7 +1546,7 @@ class BaseAPI
     ): BunnyClientResponseInterface {
         $endpoint = new GetWAFStatistics();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -1631,9 +1559,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param array<string,mixed> $query
      * @return BunnyClientResponseInterface
      */
@@ -1641,7 +1567,7 @@ class BaseAPI
     {
         $endpoint = new LoadFreeCertificate();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -1653,9 +1579,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param int $id
      * @param array<string,mixed> $body
@@ -1666,7 +1590,7 @@ class BaseAPI
     ): BunnyClientResponseInterface {
         $endpoint = new PurgeCache();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -1679,9 +1603,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param array<string,mixed> $body
      */
@@ -1689,7 +1611,7 @@ class BaseAPI
     {
         $endpoint = new CheckPullZoneAvailability();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -1701,9 +1623,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param int $id
      * @param array<string,mixed> $body
@@ -1714,7 +1634,7 @@ class BaseAPI
     ): BunnyClientResponseInterface {
         $endpoint = new AddCustomCertificate();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -1727,9 +1647,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param int $id
      * @param array<string,mixed> $body
@@ -1740,7 +1658,7 @@ class BaseAPI
     ): BunnyClientResponseInterface {
         $endpoint = new DeleteCertificate();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -1753,9 +1671,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param int $id
      * @param array<string,mixed> $body
@@ -1766,7 +1682,7 @@ class BaseAPI
     ): BunnyClientResponseInterface {
         $endpoint = new AddCustomHostname();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -1779,9 +1695,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param int $id
      * @param array<string,mixed> $body
@@ -1792,7 +1706,7 @@ class BaseAPI
     ): BunnyClientResponseInterface {
         $endpoint = new DeleteCustomHostname();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -1805,9 +1719,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param int $id
      * @param array<string,mixed> $body
@@ -1818,7 +1730,7 @@ class BaseAPI
     ): BunnyClientResponseInterface {
         $endpoint = new SetForceSSL();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -1848,9 +1760,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param int $id
      * @param array<string,mixed> $body
@@ -1861,7 +1771,7 @@ class BaseAPI
     ): BunnyClientResponseInterface {
         $endpoint = new Model\API\Base\PullZone\AddAllowedReferer();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -1874,9 +1784,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param int $id
      * @param array<string,mixed> $body
@@ -1887,7 +1795,7 @@ class BaseAPI
     ): BunnyClientResponseInterface {
         $endpoint = new Model\API\Base\PullZone\DeleteAllowedReferer();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -1900,9 +1808,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param int $id
      * @param array<string,mixed> $body
@@ -1913,7 +1819,7 @@ class BaseAPI
     ): BunnyClientResponseInterface {
         $endpoint = new Model\API\Base\PullZone\AddBlockedReferer();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -1926,9 +1832,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param int $id
      * @param array<string,mixed> $body
@@ -1939,7 +1843,7 @@ class BaseAPI
     ): BunnyClientResponseInterface {
         $endpoint = new Model\API\Base\PullZone\DeleteBlockedReferer();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -1952,9 +1856,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param int $id
      * @param array<string,mixed> $body
@@ -1965,7 +1867,7 @@ class BaseAPI
     ): BunnyClientResponseInterface {
         $endpoint = new Model\API\Base\PullZone\AddBlockedIP();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -1978,9 +1880,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param int $id
      * @param array<string,mixed> $body
@@ -1991,7 +1891,7 @@ class BaseAPI
     ): BunnyClientResponseInterface {
         $endpoint = new Model\API\Base\PullZone\DeleteBlockedIP();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -2004,9 +1904,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param array<string,mixed> $query
      * @return BunnyClientResponseInterface
      */
@@ -2014,7 +1912,7 @@ class BaseAPI
     {
         $endpoint = new PurgeURL();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -2026,9 +1924,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param array<string,mixed> $query
      * @return BunnyClientResponseInterface
      */
@@ -2036,7 +1932,7 @@ class BaseAPI
     {
         $endpoint = new PurgeURLByHeader();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -2048,9 +1944,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param array<string,mixed> $query
      * @return BunnyClientResponseInterface
      */
@@ -2058,7 +1952,7 @@ class BaseAPI
     {
         $endpoint = new GetStatistics();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -2069,10 +1963,8 @@ class BaseAPI
     /**
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
      * @throws Exception\JSONException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param array<string,mixed> $query
      * @return BunnyClientResponseInterface
      */
@@ -2080,7 +1972,7 @@ class BaseAPI
     {
         $endpoint = new GlobalSearch();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -2092,9 +1984,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param array<string,mixed> $query
      * @return BunnyClientResponseInterface
      */
@@ -2102,7 +1992,7 @@ class BaseAPI
     {
         $endpoint = new ListStorageZones();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -2114,9 +2004,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param array<string,mixed> $body
      */
@@ -2124,7 +2012,7 @@ class BaseAPI
     {
         $endpoint = new AddStorageZone();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -2136,9 +2024,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param array<string,mixed> $body
      */
@@ -2146,7 +2032,7 @@ class BaseAPI
     {
         $endpoint = new CheckStorageZoneAvailability();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -2175,9 +2061,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param int $id
      * @param array<string,mixed> $body
@@ -2188,7 +2072,7 @@ class BaseAPI
     ): BunnyClientResponseInterface {
         $endpoint = new UpdateStorageZone();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -2217,10 +2101,8 @@ class BaseAPI
     /**
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
      * @throws Exception\JSONException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param int $id
      * @param array<string,mixed> $query
      * @return BunnyClientResponseInterface
@@ -2229,7 +2111,7 @@ class BaseAPI
     {
         $endpoint = new GetStorageZoneStatistics();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -2276,9 +2158,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param array<string,mixed> $query
      * @return BunnyClientResponseInterface
      */
@@ -2286,7 +2166,7 @@ class BaseAPI
     {
         $endpoint = new Model\API\Base\StorageZone\ResetReadOnlyPassword();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -2328,9 +2208,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param array<string,mixed> $body
      */
@@ -2338,7 +2216,7 @@ class BaseAPI
     {
         $endpoint = new UpdateUserDetails();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -2395,9 +2273,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param array<string,mixed> $body
      */
@@ -2405,7 +2281,7 @@ class BaseAPI
     {
         $endpoint = new CloseAccount();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -2552,9 +2428,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param array<string,mixed> $body
      */
@@ -2562,7 +2436,7 @@ class BaseAPI
     {
         $endpoint = new DisableTwoFactorAuthentication();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -2574,9 +2448,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param array<string,mixed> $body
      */
@@ -2584,7 +2456,7 @@ class BaseAPI
     {
         $endpoint = new EnableTwoFactorAuthentication();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -2596,9 +2468,7 @@ class BaseAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param array<string,mixed> $body
      */
@@ -2606,7 +2476,7 @@ class BaseAPI
     {
         $endpoint = new VerifyTwoFactorAuthenticationCode();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,

--- a/src/EdgeScriptingAPI.php
+++ b/src/EdgeScriptingAPI.php
@@ -8,11 +8,10 @@ use Psr\Http\Client\ClientExceptionInterface;
 use ToshY\BunnyNet\Client\BunnyClient;
 use ToshY\BunnyNet\Enum\Host;
 use ToshY\BunnyNet\Exception\BunnyClientResponseException;
-use ToshY\BunnyNet\Exception\InvalidTypeForKeyValueException;
-use ToshY\BunnyNet\Exception\InvalidTypeForListValueException;
 use ToshY\BunnyNet\Exception\JSONException;
-use ToshY\BunnyNet\Exception\ParameterIsRequiredException;
 use ToshY\BunnyNet\Helper\BodyContentHelper;
+use ToshY\BunnyNet\Model\API\EdgeScripting\Code\GetCode;
+use ToshY\BunnyNet\Model\API\EdgeScripting\Code\SetCode;
 use ToshY\BunnyNet\Model\API\EdgeScripting\EdgeScript\AddEdgeScript;
 use ToshY\BunnyNet\Model\API\EdgeScripting\EdgeScript\DeleteEdgeScript;
 use ToshY\BunnyNet\Model\API\EdgeScripting\EdgeScript\GetEdgeScript;
@@ -20,8 +19,6 @@ use ToshY\BunnyNet\Model\API\EdgeScripting\EdgeScript\GetEdgeScriptStatistics;
 use ToshY\BunnyNet\Model\API\EdgeScripting\EdgeScript\ListEdgeScripts;
 use ToshY\BunnyNet\Model\API\EdgeScripting\EdgeScript\RotateDeploymentKey;
 use ToshY\BunnyNet\Model\API\EdgeScripting\EdgeScript\UpdateEdgeScript;
-use ToshY\BunnyNet\Model\API\EdgeScripting\Code\GetCode;
-use ToshY\BunnyNet\Model\API\EdgeScripting\Code\SetCode;
 use ToshY\BunnyNet\Model\API\EdgeScripting\Release\GetActiveReleases;
 use ToshY\BunnyNet\Model\API\EdgeScripting\Release\GetReleases;
 use ToshY\BunnyNet\Model\API\EdgeScripting\Release\PublishRelease;
@@ -37,17 +34,19 @@ use ToshY\BunnyNet\Model\API\EdgeScripting\Variable\GetVariable;
 use ToshY\BunnyNet\Model\API\EdgeScripting\Variable\UpdateVariable;
 use ToshY\BunnyNet\Model\API\EdgeScripting\Variable\UpsertVariable;
 use ToshY\BunnyNet\Model\Client\Interface\BunnyClientResponseInterface;
-use ToshY\BunnyNet\Validator\ParameterValidator;
+use ToshY\BunnyNet\Validation\BunnyValidator;
 
 class EdgeScriptingAPI
 {
     /**
      * @param string $apiKey
      * @param BunnyClient $client
+     * @param BunnyValidator $validator
      */
     public function __construct(
         protected readonly string $apiKey,
         protected readonly BunnyClient $client,
+        protected readonly BunnyValidator $validator = new BunnyValidator(),
     ) {
         $this->client
             ->setApiKey($this->apiKey)
@@ -75,9 +74,7 @@ class EdgeScriptingAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param int $id
      * @param array<string,mixed> $body
@@ -88,7 +85,7 @@ class EdgeScriptingAPI
     ): BunnyClientResponseInterface {
         $endpoint = new SetCode();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -100,10 +97,8 @@ class EdgeScriptingAPI
     /**
      * @throws ClientExceptionInterface
      * @throws BunnyClientResponseException
-     * @throws InvalidTypeForKeyValueException
-     * @throws InvalidTypeForListValueException
      * @throws JSONException
-     * @throws ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param int $id
      * @param array<string,mixed> $query
      * @return BunnyClientResponseInterface
@@ -112,7 +107,7 @@ class EdgeScriptingAPI
     {
         $endpoint = new DeleteEdgeScript();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -142,9 +137,7 @@ class EdgeScriptingAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param int $id
      * @param array<string,mixed> $body
@@ -153,7 +146,7 @@ class EdgeScriptingAPI
     {
         $endpoint = new UpdateEdgeScript();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -165,10 +158,8 @@ class EdgeScriptingAPI
     /**
      * @throws ClientExceptionInterface
      * @throws BunnyClientResponseException
-     * @throws InvalidTypeForKeyValueException
-     * @throws InvalidTypeForListValueException
      * @throws JSONException
-     * @throws ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param int $id
      * @param array<string,mixed> $query
      * @return BunnyClientResponseInterface
@@ -177,7 +168,7 @@ class EdgeScriptingAPI
     {
         $endpoint = new GetEdgeScriptStatistics();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -190,9 +181,7 @@ class EdgeScriptingAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param array<string,mixed> $query
      * @return BunnyClientResponseInterface
      */
@@ -200,7 +189,7 @@ class EdgeScriptingAPI
     {
         $endpoint = new ListEdgeScripts();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -212,9 +201,7 @@ class EdgeScriptingAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param array<string,mixed> $body
      */
@@ -222,7 +209,7 @@ class EdgeScriptingAPI
     {
         $endpoint = new AddEdgeScript();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -251,9 +238,7 @@ class EdgeScriptingAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param int $id
      * @param array<string,mixed> $body
@@ -264,7 +249,7 @@ class EdgeScriptingAPI
     ): BunnyClientResponseInterface {
         $endpoint = new AddVariable();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -317,9 +302,7 @@ class EdgeScriptingAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param int $variableId
      * @param array<string,mixed> $body
      * @return BunnyClientResponseInterface
@@ -332,7 +315,7 @@ class EdgeScriptingAPI
     ): BunnyClientResponseInterface {
         $endpoint = new UpdateVariable();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -345,9 +328,7 @@ class EdgeScriptingAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param array<string,mixed> $body
      * @return BunnyClientResponseInterface
      * @param int $id
@@ -358,7 +339,7 @@ class EdgeScriptingAPI
     ): BunnyClientResponseInterface {
         $endpoint = new UpsertVariable();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -371,9 +352,7 @@ class EdgeScriptingAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param int $id
      * @param array<string,mixed> $body
@@ -384,7 +363,7 @@ class EdgeScriptingAPI
     ): BunnyClientResponseInterface {
         $endpoint = new AddSecret();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -397,9 +376,7 @@ class EdgeScriptingAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param int $id
      * @return BunnyClientResponseInterface
      */
@@ -417,9 +394,7 @@ class EdgeScriptingAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param array<string,mixed> $body
      * @return BunnyClientResponseInterface
      * @param int $id
@@ -430,7 +405,7 @@ class EdgeScriptingAPI
     ): BunnyClientResponseInterface {
         $endpoint = new UpsertSecret();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -463,9 +438,7 @@ class EdgeScriptingAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param int $secretId
      * @param array<string,mixed> $body
      * @return BunnyClientResponseInterface
@@ -478,7 +451,7 @@ class EdgeScriptingAPI
     ): BunnyClientResponseInterface {
         $endpoint = new UpdateSecret();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -508,9 +481,7 @@ class EdgeScriptingAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param array<string,mixed> $query
      * @return BunnyClientResponseInterface
      * @param int $id
@@ -521,7 +492,7 @@ class EdgeScriptingAPI
     ): BunnyClientResponseInterface {
         $endpoint = new GetReleases();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -534,9 +505,7 @@ class EdgeScriptingAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param array<string,mixed> $body
      * @return BunnyClientResponseInterface
      * @param int $id
@@ -547,7 +516,7 @@ class EdgeScriptingAPI
     ): BunnyClientResponseInterface {
         $endpoint = new PublishRelease();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -560,9 +529,7 @@ class EdgeScriptingAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param string $uuid
      * @param array<string,mixed> $body
      * @return BunnyClientResponseInterface
@@ -575,7 +542,7 @@ class EdgeScriptingAPI
     ): BunnyClientResponseInterface {
         $endpoint = new PublishReleaseByPathParameter();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,

--- a/src/EdgeStorageAPI.php
+++ b/src/EdgeStorageAPI.php
@@ -14,7 +14,7 @@ use ToshY\BunnyNet\Model\API\EdgeStorage\ManageFiles\DownloadFile;
 use ToshY\BunnyNet\Model\API\EdgeStorage\ManageFiles\DownloadZip;
 use ToshY\BunnyNet\Model\API\EdgeStorage\ManageFiles\UploadFile;
 use ToshY\BunnyNet\Model\Client\Interface\BunnyClientResponseInterface;
-use ToshY\BunnyNet\Validator\ParameterValidator;
+use ToshY\BunnyNet\Validation\BunnyValidator;
 
 class EdgeStorageAPI
 {
@@ -22,11 +22,13 @@ class EdgeStorageAPI
      * @param string $apiKey
      * @param BunnyClient $client
      * @param Region $region
+     * @param BunnyValidator $validator
      */
     public function __construct(
         protected readonly string $apiKey,
         protected readonly BunnyClient $client,
         Region $region = Region::FS,
+        protected readonly BunnyValidator $validator = new BunnyValidator(),
     ) {
         $this->client
             ->setApiKey($this->apiKey)
@@ -58,10 +60,8 @@ class EdgeStorageAPI
     /**
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
      * @throws Exception\JSONException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param string $storageZoneName
      * @param mixed $body
      * @return BunnyClientResponseInterface
@@ -72,7 +72,7 @@ class EdgeStorageAPI
     ): BunnyClientResponseInterface {
         $endpoint = new DownloadZip();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,

--- a/src/Enum/ModelStrategy.php
+++ b/src/Enum/ModelStrategy.php
@@ -1,0 +1,492 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ToshY\BunnyNet\Enum;
+
+use ToshY\BunnyNet\Model\API\Base\AbuseCase\CheckAbuseCase;
+use ToshY\BunnyNet\Model\API\Base\AbuseCase\GetAbuseCase;
+use ToshY\BunnyNet\Model\API\Base\AbuseCase\GetDMCACase;
+use ToshY\BunnyNet\Model\API\Base\AbuseCase\ListAbuseCases;
+use ToshY\BunnyNet\Model\API\Base\AbuseCase\ResolveAbuseCase;
+use ToshY\BunnyNet\Model\API\Base\AbuseCase\ResolveDMCACase;
+use ToshY\BunnyNet\Model\API\Base\APIKeys\ListAPIKeys;
+use ToshY\BunnyNet\Model\API\Base\Auth\AuthJwt2fa;
+use ToshY\BunnyNet\Model\API\Base\Auth\RefreshJwt;
+use ToshY\BunnyNet\Model\API\Base\Billing\ApplyPromoCode;
+use ToshY\BunnyNet\Model\API\Base\Billing\ClaimAffiliateCredits;
+use ToshY\BunnyNet\Model\API\Base\Billing\ConfigureAutoRecharge;
+use ToshY\BunnyNet\Model\API\Base\Billing\CreateCoinifyPayment;
+use ToshY\BunnyNet\Model\API\Base\Billing\CreatePaymentCheckout;
+use ToshY\BunnyNet\Model\API\Base\Billing\GetAffiliateDetails;
+use ToshY\BunnyNet\Model\API\Base\Billing\GetBillingDetails;
+use ToshY\BunnyNet\Model\API\Base\Billing\GetBillingSummary;
+use ToshY\BunnyNet\Model\API\Base\Billing\GetBillingSummaryPDF;
+use ToshY\BunnyNet\Model\API\Base\Billing\GetCoinifyBitcoinExchangeRate;
+use ToshY\BunnyNet\Model\API\Base\Billing\PreparePaymentAuthorization;
+use ToshY\BunnyNet\Model\API\Base\Countries\ListCountries;
+use ToshY\BunnyNet\Model\API\Base\DNSZone\AddDNSRecord;
+use ToshY\BunnyNet\Model\API\Base\DNSZone\AddDNSZone;
+use ToshY\BunnyNet\Model\API\Base\DNSZone\CheckDNSZoneAvailability;
+use ToshY\BunnyNet\Model\API\Base\DNSZone\DeleteDNSRecord;
+use ToshY\BunnyNet\Model\API\Base\DNSZone\DeleteDNSZone;
+use ToshY\BunnyNet\Model\API\Base\DNSZone\DisableDNSSECOnDNSZone;
+use ToshY\BunnyNet\Model\API\Base\DNSZone\DismissDNSConfigurationNotice;
+use ToshY\BunnyNet\Model\API\Base\DNSZone\EnableDNSSECOnDNSZone;
+use ToshY\BunnyNet\Model\API\Base\DNSZone\ExportDNSRecords;
+use ToshY\BunnyNet\Model\API\Base\DNSZone\GetDNSZone;
+use ToshY\BunnyNet\Model\API\Base\DNSZone\GetDNSZoneQueryStatistics;
+use ToshY\BunnyNet\Model\API\Base\DNSZone\ImportDNSRecords;
+use ToshY\BunnyNet\Model\API\Base\DNSZone\ListDNSZones;
+use ToshY\BunnyNet\Model\API\Base\DNSZone\RecheckDNSConfiguration;
+use ToshY\BunnyNet\Model\API\Base\DNSZone\UpdateDNSRecord;
+use ToshY\BunnyNet\Model\API\Base\DNSZone\UpdateDNSZone;
+use ToshY\BunnyNet\Model\API\Base\DRMCertificate\ListDRMCertificates;
+use ToshY\BunnyNet\Model\API\Base\Integration\GetGitHubIntegration;
+use ToshY\BunnyNet\Model\API\Base\PullZone\AddAllowedReferer as PullZoneAddAllowedReferer;
+use ToshY\BunnyNet\Model\API\Base\PullZone\AddBlockedIP;
+use ToshY\BunnyNet\Model\API\Base\PullZone\AddBlockedReferer as PullZoneAddBlockedReferer;
+use ToshY\BunnyNet\Model\API\Base\PullZone\AddCustomCertificate;
+use ToshY\BunnyNet\Model\API\Base\PullZone\AddCustomHostname;
+use ToshY\BunnyNet\Model\API\Base\PullZone\AddOrUpdateEdgeRule;
+use ToshY\BunnyNet\Model\API\Base\PullZone\AddPullZone;
+use ToshY\BunnyNet\Model\API\Base\PullZone\CheckPullZoneAvailability;
+use ToshY\BunnyNet\Model\API\Base\PullZone\DeleteAllowedReferer as PullZoneDeleteAllowedReferer;
+use ToshY\BunnyNet\Model\API\Base\PullZone\DeleteBlockedIP;
+use ToshY\BunnyNet\Model\API\Base\PullZone\DeleteBlockedReferer as PullZoneDeleteBlockedReferer;
+use ToshY\BunnyNet\Model\API\Base\PullZone\DeleteCertificate;
+use ToshY\BunnyNet\Model\API\Base\PullZone\DeleteCustomHostname;
+use ToshY\BunnyNet\Model\API\Base\PullZone\DeleteEdgeRule;
+use ToshY\BunnyNet\Model\API\Base\PullZone\DeletePullZone;
+use ToshY\BunnyNet\Model\API\Base\PullZone\GetOptimizerStatistics;
+use ToshY\BunnyNet\Model\API\Base\PullZone\GetOriginShieldQueueStatistics;
+use ToshY\BunnyNet\Model\API\Base\PullZone\GetPullZone;
+use ToshY\BunnyNet\Model\API\Base\PullZone\GetSafeHopStatistics;
+use ToshY\BunnyNet\Model\API\Base\PullZone\GetWAFStatistics;
+use ToshY\BunnyNet\Model\API\Base\PullZone\ListPullZones;
+use ToshY\BunnyNet\Model\API\Base\PullZone\LoadFreeCertificate;
+use ToshY\BunnyNet\Model\API\Base\PullZone\PurgeCache;
+use ToshY\BunnyNet\Model\API\Base\PullZone\ResetTokenKey;
+use ToshY\BunnyNet\Model\API\Base\PullZone\SetEdgeRuleEnabled;
+use ToshY\BunnyNet\Model\API\Base\PullZone\SetForceSSL;
+use ToshY\BunnyNet\Model\API\Base\PullZone\SetZoneSecurityEnabled;
+use ToshY\BunnyNet\Model\API\Base\PullZone\SetZoneSecurityIncludeHashRemoteIPEnabled;
+use ToshY\BunnyNet\Model\API\Base\PullZone\UpdatePullZone;
+use ToshY\BunnyNet\Model\API\Base\Purge\PurgeURL;
+use ToshY\BunnyNet\Model\API\Base\Purge\PurgeURLByHeader;
+use ToshY\BunnyNet\Model\API\Base\Region\ListRegions;
+use ToshY\BunnyNet\Model\API\Base\Search\GlobalSearch;
+use ToshY\BunnyNet\Model\API\Base\Statistics\GetStatistics;
+use ToshY\BunnyNet\Model\API\Base\StorageZone\AddStorageZone;
+use ToshY\BunnyNet\Model\API\Base\StorageZone\CheckStorageZoneAvailability;
+use ToshY\BunnyNet\Model\API\Base\StorageZone\DeleteStorageZone;
+use ToshY\BunnyNet\Model\API\Base\StorageZone\GetStorageZone;
+use ToshY\BunnyNet\Model\API\Base\StorageZone\GetStorageZoneConnections;
+use ToshY\BunnyNet\Model\API\Base\StorageZone\GetStorageZoneStatistics;
+use ToshY\BunnyNet\Model\API\Base\StorageZone\ListStorageZones;
+use ToshY\BunnyNet\Model\API\Base\StorageZone\ResetPassword as StorageZoneResetPassword;
+use ToshY\BunnyNet\Model\API\Base\StorageZone\ResetReadOnlyPassword as StorageZoneResetReadOnlyPassword;
+use ToshY\BunnyNet\Model\API\Base\StorageZone\UpdateStorageZone;
+use ToshY\BunnyNet\Model\API\Base\StreamVideoLibrary\AddAllowedReferer as VideoLibraryAllowedReferer;
+use ToshY\BunnyNet\Model\API\Base\StreamVideoLibrary\AddBlockedReferer as VideoLibraryAddBlockedReferer;
+use ToshY\BunnyNet\Model\API\Base\StreamVideoLibrary\AddVideoLibrary;
+use ToshY\BunnyNet\Model\API\Base\StreamVideoLibrary\AddWatermark;
+use ToshY\BunnyNet\Model\API\Base\StreamVideoLibrary\DeleteAllowedReferer as VideoLibraryDeleteAllowedReferer;
+use ToshY\BunnyNet\Model\API\Base\StreamVideoLibrary\DeleteBlockedReferer as VideoLibraryDeleteBlockedReferer;
+use ToshY\BunnyNet\Model\API\Base\StreamVideoLibrary\DeleteVideoLibrary;
+use ToshY\BunnyNet\Model\API\Base\StreamVideoLibrary\DeleteWatermark;
+use ToshY\BunnyNet\Model\API\Base\StreamVideoLibrary\GetLanguages;
+use ToshY\BunnyNet\Model\API\Base\StreamVideoLibrary\GetVideoLibrary;
+use ToshY\BunnyNet\Model\API\Base\StreamVideoLibrary\ListVideoLibraries;
+use ToshY\BunnyNet\Model\API\Base\StreamVideoLibrary\ResetPassword as VideoLibraryResetPassword;
+use ToshY\BunnyNet\Model\API\Base\StreamVideoLibrary\ResetPasswordByPathParameter as VideoLibraryResetPasswordByPathParameter;
+use ToshY\BunnyNet\Model\API\Base\StreamVideoLibrary\UpdateVideoLibrary;
+use ToshY\BunnyNet\Model\API\Base\Support\CloseTicket;
+use ToshY\BunnyNet\Model\API\Base\Support\CreateTicket;
+use ToshY\BunnyNet\Model\API\Base\Support\GetTicketDetails;
+use ToshY\BunnyNet\Model\API\Base\Support\ListTickets;
+use ToshY\BunnyNet\Model\API\Base\Support\ReplyTicket;
+use ToshY\BunnyNet\Model\API\Base\User\AcceptDPA;
+use ToshY\BunnyNet\Model\API\Base\User\CloseAccount;
+use ToshY\BunnyNet\Model\API\Base\User\DisableTwoFactorAuthentication;
+use ToshY\BunnyNet\Model\API\Base\User\EnableTwoFactorAuthentication;
+use ToshY\BunnyNet\Model\API\Base\User\GenerateTwoFactorAuthenticationVerification;
+use ToshY\BunnyNet\Model\API\Base\User\GetDPADetails;
+use ToshY\BunnyNet\Model\API\Base\User\GetDPADetailsHTML;
+use ToshY\BunnyNet\Model\API\Base\User\GetHomeFeed;
+use ToshY\BunnyNet\Model\API\Base\User\GetMarketingDetails;
+use ToshY\BunnyNet\Model\API\Base\User\GetUserDetails;
+use ToshY\BunnyNet\Model\API\Base\User\GetWhatsNewItems;
+use ToshY\BunnyNet\Model\API\Base\User\ListCloseAccountReasons;
+use ToshY\BunnyNet\Model\API\Base\User\ListNotifications;
+use ToshY\BunnyNet\Model\API\Base\User\ResendEmailConfirmation;
+use ToshY\BunnyNet\Model\API\Base\User\ResetAPIKey;
+use ToshY\BunnyNet\Model\API\Base\User\ResetWhatsNew;
+use ToshY\BunnyNet\Model\API\Base\User\SetNotificationsOpened;
+use ToshY\BunnyNet\Model\API\Base\User\UpdateUserDetails;
+use ToshY\BunnyNet\Model\API\Base\User\VerifyTwoFactorAuthenticationCode;
+use ToshY\BunnyNet\Model\API\EdgeScripting\Code\GetCode;
+use ToshY\BunnyNet\Model\API\EdgeScripting\Code\SetCode;
+use ToshY\BunnyNet\Model\API\EdgeScripting\EdgeScript\AddEdgeScript;
+use ToshY\BunnyNet\Model\API\EdgeScripting\EdgeScript\DeleteEdgeScript;
+use ToshY\BunnyNet\Model\API\EdgeScripting\EdgeScript\GetEdgeScript;
+use ToshY\BunnyNet\Model\API\EdgeScripting\EdgeScript\GetEdgeScriptStatistics;
+use ToshY\BunnyNet\Model\API\EdgeScripting\EdgeScript\ListEdgeScripts;
+use ToshY\BunnyNet\Model\API\EdgeScripting\EdgeScript\RotateDeploymentKey;
+use ToshY\BunnyNet\Model\API\EdgeScripting\EdgeScript\UpdateEdgeScript;
+use ToshY\BunnyNet\Model\API\EdgeScripting\Release\GetActiveReleases;
+use ToshY\BunnyNet\Model\API\EdgeScripting\Release\GetReleases;
+use ToshY\BunnyNet\Model\API\EdgeScripting\Release\PublishRelease;
+use ToshY\BunnyNet\Model\API\EdgeScripting\Release\PublishReleaseByPathParameter;
+use ToshY\BunnyNet\Model\API\EdgeScripting\Secret\AddSecret;
+use ToshY\BunnyNet\Model\API\EdgeScripting\Secret\DeleteSecret;
+use ToshY\BunnyNet\Model\API\EdgeScripting\Secret\ListSecrets;
+use ToshY\BunnyNet\Model\API\EdgeScripting\Secret\UpdateSecret;
+use ToshY\BunnyNet\Model\API\EdgeScripting\Secret\UpsertSecret;
+use ToshY\BunnyNet\Model\API\EdgeScripting\Variable\AddVariable;
+use ToshY\BunnyNet\Model\API\EdgeScripting\Variable\DeleteVariable;
+use ToshY\BunnyNet\Model\API\EdgeScripting\Variable\GetVariable;
+use ToshY\BunnyNet\Model\API\EdgeScripting\Variable\UpdateVariable;
+use ToshY\BunnyNet\Model\API\EdgeScripting\Variable\UpsertVariable;
+use ToshY\BunnyNet\Model\API\EdgeStorage\BrowseFiles\ListFiles;
+use ToshY\BunnyNet\Model\API\EdgeStorage\ManageFiles\DeleteFile;
+use ToshY\BunnyNet\Model\API\EdgeStorage\ManageFiles\DownloadFile;
+use ToshY\BunnyNet\Model\API\EdgeStorage\ManageFiles\DownloadZip;
+use ToshY\BunnyNet\Model\API\EdgeStorage\ManageFiles\UploadFile;
+use ToshY\BunnyNet\Model\API\Logging\GetLog;
+use ToshY\BunnyNet\Model\API\Shield\DDoS\ListDDoSEnums;
+use ToshY\BunnyNet\Model\API\Shield\EventLogs\ListEventLogs;
+use ToshY\BunnyNet\Model\API\Shield\Metrics\GetOverviewMetrics;
+use ToshY\BunnyNet\Model\API\Shield\Metrics\GetRateLimitMetrics;
+use ToshY\BunnyNet\Model\API\Shield\Metrics\GetWAFRuleMetrics;
+use ToshY\BunnyNet\Model\API\Shield\Metrics\ListRateLimitMetrics;
+use ToshY\BunnyNet\Model\API\Shield\RateLimiting\CreateRateLimit;
+use ToshY\BunnyNet\Model\API\Shield\RateLimiting\DeleteRateLimit;
+use ToshY\BunnyNet\Model\API\Shield\RateLimiting\GetRateLimit;
+use ToshY\BunnyNet\Model\API\Shield\RateLimiting\ListRateLimits;
+use ToshY\BunnyNet\Model\API\Shield\RateLimiting\UpdateRateLimit;
+use ToshY\BunnyNet\Model\API\Shield\WAF\CreateCustomWAFRule;
+use ToshY\BunnyNet\Model\API\Shield\WAF\DeleteCustomWAFRule;
+use ToshY\BunnyNet\Model\API\Shield\WAF\GetCustomWAFRule;
+use ToshY\BunnyNet\Model\API\Shield\WAF\ListCustomWAFRules;
+use ToshY\BunnyNet\Model\API\Shield\WAF\ListWAFEngineConfiguration;
+use ToshY\BunnyNet\Model\API\Shield\WAF\ListWAFEnums;
+use ToshY\BunnyNet\Model\API\Shield\WAF\ListWAFProfiles;
+use ToshY\BunnyNet\Model\API\Shield\WAF\ListWAFRules;
+use ToshY\BunnyNet\Model\API\Shield\WAF\ReviewTriggeredRule;
+use ToshY\BunnyNet\Model\API\Shield\WAF\ReviewTriggeredRuleAIRecommendation;
+use ToshY\BunnyNet\Model\API\Shield\WAF\ReviewTriggeredRules;
+use ToshY\BunnyNet\Model\API\Shield\WAF\UpdateCustomWAFRule;
+use ToshY\BunnyNet\Model\API\Shield\WAF\UpdateCustomWAFRuleByPatch;
+use ToshY\BunnyNet\Model\API\Shield\Zone\CreateShieldZone;
+use ToshY\BunnyNet\Model\API\Shield\Zone\GetShieldZone;
+use ToshY\BunnyNet\Model\API\Shield\Zone\GetShieldZoneByPullZoneId;
+use ToshY\BunnyNet\Model\API\Shield\Zone\ListShieldZones;
+use ToshY\BunnyNet\Model\API\Shield\Zone\UpdateShieldZone;
+use ToshY\BunnyNet\Model\API\Stream\ManageCollections\CreateCollection;
+use ToshY\BunnyNet\Model\API\Stream\ManageCollections\DeleteCollection;
+use ToshY\BunnyNet\Model\API\Stream\ManageCollections\GetCollection;
+use ToshY\BunnyNet\Model\API\Stream\ManageCollections\ListCollections;
+use ToshY\BunnyNet\Model\API\Stream\ManageCollections\UpdateCollection;
+use ToshY\BunnyNet\Model\API\Stream\ManageVideos\AddCaption;
+use ToshY\BunnyNet\Model\API\Stream\ManageVideos\AddOutputCodecToVideo;
+use ToshY\BunnyNet\Model\API\Stream\ManageVideos\CreateVideo;
+use ToshY\BunnyNet\Model\API\Stream\ManageVideos\DeleteCaption;
+use ToshY\BunnyNet\Model\API\Stream\ManageVideos\DeleteUnconfiguredResolutions;
+use ToshY\BunnyNet\Model\API\Stream\ManageVideos\DeleteVideo;
+use ToshY\BunnyNet\Model\API\Stream\ManageVideos\FetchVideo;
+use ToshY\BunnyNet\Model\API\Stream\ManageVideos\GetVideo;
+use ToshY\BunnyNet\Model\API\Stream\ManageVideos\GetVideoHeatmap;
+use ToshY\BunnyNet\Model\API\Stream\ManageVideos\GetVideoPlayData;
+use ToshY\BunnyNet\Model\API\Stream\ManageVideos\GetVideoResolutionsInfo;
+use ToshY\BunnyNet\Model\API\Stream\ManageVideos\ListVideos;
+use ToshY\BunnyNet\Model\API\Stream\ManageVideos\ListVideoStatistics;
+use ToshY\BunnyNet\Model\API\Stream\ManageVideos\ReEncodeVideo;
+use ToshY\BunnyNet\Model\API\Stream\ManageVideos\RepackageVideo;
+use ToshY\BunnyNet\Model\API\Stream\ManageVideos\SetThumbnail;
+use ToshY\BunnyNet\Model\API\Stream\ManageVideos\TranscribeVideo;
+use ToshY\BunnyNet\Model\API\Stream\ManageVideos\UpdateVideo;
+use ToshY\BunnyNet\Model\API\Stream\ManageVideos\UploadVideo;
+use ToshY\BunnyNet\Model\API\Stream\OEmbed\GetOEmbed;
+use ToshY\BunnyNet\Validation\Strategy\Body\NoBodyValidationStrategy;
+use ToshY\BunnyNet\Validation\Strategy\Body\StrictBodyValidationStrategy;
+use ToshY\BunnyNet\Validation\Strategy\Query\NoQueryValidationStrategy;
+use ToshY\BunnyNet\Validation\Strategy\Query\StrictQueryValidationStrategy;
+use ToshY\BunnyNet\Validation\Strategy\ValidationModelStrategy;
+
+enum ModelStrategy
+{
+    case STRICT;
+
+    case STRICT_QUERY;
+
+    case STRICT_BODY;
+
+    case NONE;
+
+    /** @var array<class-string,ModelStrategy> */
+    private const BASE = [
+        ListAbuseCases::class => self::STRICT_QUERY,
+        GetDMCACase::class => self::NONE,
+        GetAbuseCase::class => self::NONE,
+        ResolveDMCACase::class => self::NONE,
+        ResolveAbuseCase::class => self::NONE,
+        CheckAbuseCase::class => self::NONE,
+        AuthJwt2fa::class => self::STRICT_BODY,
+        RefreshJwt::class => self::NONE,
+        ListCountries::class => self::NONE,
+        ListAPIKeys::class => self::STRICT_QUERY,
+        GetBillingDetails::class => self::NONE,
+        ConfigureAutoRecharge::class => self::STRICT_BODY,
+        CreatePaymentCheckout::class => self::STRICT_BODY,
+        PreparePaymentAuthorization::class => self::NONE,
+        GetAffiliateDetails::class => self::NONE,
+        ClaimAffiliateCredits::class => self::NONE,
+        GetCoinifyBitcoinExchangeRate::class => self::NONE,
+        CreateCoinifyPayment::class => self::STRICT_QUERY,
+        GetBillingSummary::class => self::NONE,
+        GetBillingSummaryPDF::class => self::NONE,
+        ApplyPromoCode::class => self::STRICT_QUERY,
+        ListTickets::class => self::STRICT_QUERY,
+        GetTicketDetails::class => self::NONE,
+        CloseTicket::class => self::NONE,
+        ReplyTicket::class => self::STRICT_BODY,
+        CreateTicket::class => self::STRICT_BODY,
+        ListDRMCertificates::class => self::STRICT_QUERY,
+        GetGitHubIntegration::class => self::NONE,
+        ListRegions::class => self::NONE,
+        ListVideoLibraries::class => self::STRICT_QUERY,
+        AddVideoLibrary::class => self::STRICT_BODY,
+        GetVideoLibrary::class => self::NONE,
+        UpdateVideoLibrary::class => self::STRICT_BODY,
+        DeleteVideoLibrary::class => self::NONE,
+        GetLanguages::class => self::NONE,
+        VideoLibraryResetPassword::class => self::STRICT_QUERY,
+        VideoLibraryResetPasswordByPathParameter::class => self::NONE,
+        AddWatermark::class => self::NONE,
+        DeleteWatermark::class => self::NONE,
+        VideoLibraryAllowedReferer::class => self::STRICT_BODY,
+        VideoLibraryDeleteAllowedReferer::class => self::STRICT_BODY,
+        VideoLibraryAddBlockedReferer::class => self::STRICT_BODY,
+        VideoLibraryDeleteBlockedReferer::class => self::STRICT_BODY,
+        ListDNSZones::class => self::STRICT_QUERY,
+        AddDNSZone::class => self::STRICT_BODY,
+        GetDNSZone::class => self::NONE,
+        UpdateDNSZone::class => self::STRICT_BODY,
+        DeleteDNSZone::class => self::NONE,
+        EnableDNSSECOnDNSZone::class => self::NONE,
+        DisableDNSSECOnDNSZone::class => self::NONE,
+        ExportDNSRecords::class => self::NONE,
+        GetDNSZoneQueryStatistics::class => self::STRICT_QUERY,
+        CheckDNSZoneAvailability::class => self::STRICT_BODY,
+        AddDNSRecord::class => self::STRICT_BODY,
+        UpdateDNSRecord::class => self::STRICT_BODY,
+        DeleteDNSRecord::class => self::NONE,
+        RecheckDNSConfiguration::class => self::NONE,
+        DismissDNSConfigurationNotice::class => self::NONE,
+        ImportDNSRecords::class => self::NONE,
+        ListPullZones::class => self::STRICT_QUERY,
+        AddPullZone::class => self::STRICT_BODY,
+        GetPullZone::class => self::STRICT_QUERY,
+        UpdatePullZone::class => self::STRICT_BODY,
+        DeletePullZone::class => self::NONE,
+        DeleteEdgeRule::class => self::NONE,
+        AddOrUpdateEdgeRule::class => self::STRICT_BODY,
+        SetEdgeRuleEnabled::class => self::STRICT_BODY,
+        SetZoneSecurityEnabled::class => self::NONE,
+        SetZoneSecurityIncludeHashRemoteIPEnabled::class => self::NONE,
+        GetOriginShieldQueueStatistics::class => self::STRICT_QUERY,
+        GetSafeHopStatistics::class => self::STRICT_QUERY,
+        GetOptimizerStatistics::class => self::STRICT_QUERY,
+        GetWAFStatistics::class => self::STRICT_QUERY,
+        LoadFreeCertificate::class => self::STRICT_QUERY,
+        PurgeCache::class => self::STRICT_BODY,
+        CheckPullZoneAvailability::class => self::STRICT_BODY,
+        AddCustomCertificate::class => self::STRICT_BODY,
+        DeleteCertificate::class => self::STRICT_BODY,
+        AddCustomHostname::class => self::STRICT_BODY,
+        DeleteCustomHostname::class => self::STRICT_BODY,
+        SetForceSSL::class => self::STRICT_BODY,
+        ResetTokenKey::class => self::NONE,
+        PullZoneAddAllowedReferer::class => self::STRICT_BODY,
+        PullZoneDeleteAllowedReferer::class => self::STRICT_BODY,
+        PullZoneAddBlockedReferer::class => self::STRICT_BODY,
+        PullZoneDeleteBlockedReferer::class => self::STRICT_BODY,
+        AddBlockedIP::class => self::STRICT_BODY,
+        DeleteBlockedIP::class => self::STRICT_BODY,
+        PurgeURL::class => self::STRICT_QUERY,
+        PurgeURLByHeader::class => self::STRICT_QUERY,
+        GetStatistics::class => self::STRICT_QUERY,
+        GlobalSearch::class => self::STRICT_QUERY,
+        ListStorageZones::class => self::STRICT_QUERY,
+        AddStorageZone::class => self::STRICT_BODY,
+        CheckStorageZoneAvailability::class => self::STRICT_BODY,
+        GetStorageZone::class => self::NONE,
+        UpdateStorageZone::class => self::STRICT_BODY,
+        DeleteStorageZone::class => self::NONE,
+        GetStorageZoneStatistics::class => self::STRICT_QUERY,
+        GetStorageZoneConnections::class => self::NONE,
+        StorageZoneResetPassword::class => self::NONE,
+        StorageZoneResetReadOnlyPassword::class => self::STRICT_QUERY,
+        GetHomeFeed::class => self::NONE,
+        GetUserDetails::class => self::NONE,
+        UpdateUserDetails::class => self::STRICT_BODY,
+        ResendEmailConfirmation::class => self::NONE,
+        ResetAPIKey::class => self::NONE,
+        ListCloseAccountReasons::class => self::NONE,
+        CloseAccount::class => self::STRICT_BODY,
+        GetDPADetails::class => self::NONE,
+        AcceptDPA::class => self::NONE,
+        GetDPADetailsHTML::class => self::NONE,
+        ListNotifications::class => self::NONE,
+        SetNotificationsOpened::class => self::NONE,
+        GetMarketingDetails::class => self::NONE,
+        GetWhatsNewItems::class => self::NONE,
+        ResetWhatsNew::class => self::NONE,
+        GenerateTwoFactorAuthenticationVerification::class => self::NONE,
+        DisableTwoFactorAuthentication::class => self::STRICT_BODY,
+        EnableTwoFactorAuthentication::class => self::STRICT_BODY,
+        VerifyTwoFactorAuthenticationCode::class => self::STRICT_BODY,
+    ];
+
+    /** @var array<class-string,ModelStrategy> */
+    private const EDGE_SCRIPTING = [
+        GetCode::class => self::NONE,
+        SetCode::class => self::STRICT_BODY,
+        DeleteEdgeScript::class => self::STRICT_QUERY,
+        GetEdgeScript::class => self::NONE,
+        UpdateEdgeScript::class => self::STRICT_BODY,
+        GetEdgeScriptStatistics::class => self::STRICT_QUERY,
+        ListEdgeScripts::class => self::STRICT_QUERY,
+        AddEdgeScript::class => self::STRICT_BODY,
+        RotateDeploymentKey::class => self::NONE,
+        AddVariable::class => self::STRICT_BODY,
+        DeleteVariable::class => self::NONE,
+        GetVariable::class => self::NONE,
+        UpdateVariable::class => self::STRICT_BODY,
+        UpsertVariable::class => self::STRICT_BODY,
+        AddSecret::class => self::STRICT_BODY,
+        ListSecrets::class => self::NONE,
+        UpsertSecret::class => self::STRICT_BODY,
+        DeleteSecret::class => self::NONE,
+        UpdateSecret::class => self::STRICT_BODY,
+        GetActiveReleases::class => self::NONE,
+        GetReleases::class => self::STRICT_QUERY,
+        PublishRelease::class => self::STRICT_BODY,
+        PublishReleaseByPathParameter::class => self::STRICT_BODY,
+    ];
+
+    /** @var array<class-string,ModelStrategy> */
+    private const EDGE_STORAGE = [
+        DownloadFile::class => self::NONE,
+        DownloadZip::class => self::STRICT_BODY,
+        UploadFile::class => self::NONE,
+        DeleteFile::class => self::NONE,
+        ListFiles::class => self::NONE,
+    ];
+
+
+    /** @var array<class-string,ModelStrategy> */
+    private const LOGGING = [
+        GetLog::class => self::STRICT_QUERY,
+    ];
+
+    /** @var array<class-string,ModelStrategy> */
+    private const SHIELD = [
+        ListShieldZones::class => self::STRICT_QUERY,
+        GetShieldZone::class => self::NONE,
+        GetShieldZoneByPullZoneId::class => self::NONE,
+        CreateShieldZone::class => self::STRICT_BODY,
+        UpdateShieldZone::class => self::STRICT_BODY,
+        ListWAFRules::class => self::NONE,
+        ReviewTriggeredRules::class => self::NONE,
+        ReviewTriggeredRule::class => self::STRICT_BODY,
+        ReviewTriggeredRuleAIRecommendation::class => self::NONE,
+        ListCustomWAFRules::class => self::STRICT_QUERY,
+        GetCustomWAFRule::class => self::NONE,
+        UpdateCustomWAFRule::class => self::STRICT_BODY,
+        UpdateCustomWAFRuleByPatch::class => self::STRICT_BODY,
+        DeleteCustomWAFRule::class => self::NONE,
+        CreateCustomWAFRule::class => self::STRICT_BODY,
+        ListWAFProfiles::class => self::NONE,
+        ListWAFEnums::class => self::NONE,
+        ListWAFEngineConfiguration::class => self::NONE,
+        ListDDoSEnums::class => self::NONE,
+        ListRateLimits::class => self::STRICT_QUERY,
+        GetRateLimit::class => self::NONE,
+        UpdateRateLimit::class => self::STRICT_BODY,
+        DeleteRateLimit::class => self::NONE,
+        CreateRateLimit::class => self::STRICT_BODY,
+        GetOverviewMetrics::class => self::NONE,
+        ListRateLimitMetrics::class => self::NONE,
+        GetRateLimitMetrics::class => self::NONE,
+        GetWAFRuleMetrics::class => self::NONE,
+        ListEventLogs::class => self::NONE,
+    ];
+
+    /** @var array<class-string,ModelStrategy> */
+    private const STREAM = [
+        GetCollection::class => self::STRICT_QUERY,
+        UpdateCollection::class => self::STRICT_BODY,
+        DeleteCollection::class => self::NONE,
+        ListCollections::class => self::STRICT_QUERY,
+        CreateCollection::class => self::STRICT_BODY,
+        GetVideo::class => self::NONE,
+        UpdateVideo::class => self::STRICT_BODY,
+        DeleteVideo::class => self::NONE,
+        CreateVideo::class => self::STRICT_BODY,
+        UploadVideo::class => self::STRICT_QUERY,
+        GetVideoHeatmap::class => self::NONE,
+        GetVideoPlayData::class => self::STRICT_QUERY,
+        ListVideoStatistics::class => self::STRICT_QUERY,
+        ReEncodeVideo::class => self::NONE,
+        AddOutputCodecToVideo::class => self::NONE,
+        RepackageVideo::class => self::STRICT_QUERY,
+        ListVideos::class => self::STRICT_QUERY,
+        SetThumbnail::class => self::STRICT_QUERY,
+        FetchVideo::class => self::STRICT,
+        AddCaption::class => self::STRICT_BODY,
+        DeleteCaption::class => self::NONE,
+        TranscribeVideo::class => self::STRICT_QUERY,
+        GetVideoResolutionsInfo::class => self::NONE,
+        DeleteUnconfiguredResolutions::class => self::STRICT_QUERY,
+        GetOEmbed::class => self::STRICT_QUERY,
+    ];
+
+    /**
+     * @return array<class-string,ModelStrategy>
+     */
+    public static function all(): array
+    {
+        return array_merge(
+            self::BASE,
+            self::EDGE_SCRIPTING,
+            self::EDGE_STORAGE,
+            self::LOGGING,
+            self::SHIELD,
+            self::STREAM,
+        );
+    }
+
+    public function validationStrategy(): ValidationModelStrategy
+    {
+        return match ($this) {
+            self::STRICT => new ValidationModelStrategy(
+                query: new StrictQueryValidationStrategy(),
+                body: new StrictBodyValidationStrategy(),
+            ),
+            self::STRICT_QUERY => new ValidationModelStrategy(
+                query: new StrictQueryValidationStrategy(),
+                body: new NoBodyValidationStrategy(),
+            ),
+            self::STRICT_BODY => new ValidationModelStrategy(
+                query: new NoQueryValidationStrategy(),
+                body: new StrictBodyValidationStrategy(),
+            ),
+            self::NONE => new ValidationModelStrategy(
+                query: new NoQueryValidationStrategy(),
+                body: new NoBodyValidationStrategy(),
+            ),
+        };
+    }
+}

--- a/src/Enum/ModelStrategy.php
+++ b/src/Enum/ModelStrategy.php
@@ -208,8 +208,10 @@ use ToshY\BunnyNet\Model\API\Stream\ManageVideos\TranscribeVideo;
 use ToshY\BunnyNet\Model\API\Stream\ManageVideos\UpdateVideo;
 use ToshY\BunnyNet\Model\API\Stream\ManageVideos\UploadVideo;
 use ToshY\BunnyNet\Model\API\Stream\OEmbed\GetOEmbed;
+use ToshY\BunnyNet\Validation\Strategy\Body\LaxBodyValidationStrategy;
 use ToshY\BunnyNet\Validation\Strategy\Body\NoBodyValidationStrategy;
 use ToshY\BunnyNet\Validation\Strategy\Body\StrictBodyValidationStrategy;
+use ToshY\BunnyNet\Validation\Strategy\Query\LaxQueryValidationStrategy;
 use ToshY\BunnyNet\Validation\Strategy\Query\NoQueryValidationStrategy;
 use ToshY\BunnyNet\Validation\Strategy\Query\StrictQueryValidationStrategy;
 use ToshY\BunnyNet\Validation\Strategy\ValidationModelStrategy;
@@ -221,6 +223,8 @@ enum ModelStrategy
     case STRICT_QUERY;
 
     case STRICT_BODY;
+
+    case LAX;
 
     case NONE;
 
@@ -482,6 +486,10 @@ enum ModelStrategy
             self::STRICT_BODY => new ValidationModelStrategy(
                 query: new NoQueryValidationStrategy(),
                 body: new StrictBodyValidationStrategy(),
+            ),
+            self::LAX => new ValidationModelStrategy(
+                query: new LaxQueryValidationStrategy(),
+                body: new LaxBodyValidationStrategy(),
             ),
             self::NONE => new ValidationModelStrategy(
                 query: new NoQueryValidationStrategy(),

--- a/src/Enum/ValidationType.php
+++ b/src/Enum/ValidationType.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ToshY\BunnyNet\Enum;
+
+enum ValidationType
+{
+    /** model-based validation */
+    case MODEL;
+
+    /** no validation */
+    case NONE;
+
+    /**
+     * @param array<class-string,ModelStrategy> $modelStrategyOverride
+     * @return array<class-string,ModelStrategy>
+     */
+    public function getStrategy(array $modelStrategyOverride): array
+    {
+        return match ($this) {
+            self::NONE => [],
+            self::MODEL => array_merge(
+                ModelStrategy::all(),
+                $modelStrategyOverride,
+            ),
+        };
+    }
+}

--- a/src/Exception/Validation/BunnyValidatorExceptionInterface.php
+++ b/src/Exception/Validation/BunnyValidatorExceptionInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ToshY\BunnyNet\Exception\Validation;
+
+use Throwable;
+
+interface BunnyValidatorExceptionInterface extends Throwable
+{
+}

--- a/src/Exception/Validation/InvalidTypeForKeyValueException.php
+++ b/src/Exception/Validation/InvalidTypeForKeyValueException.php
@@ -2,24 +2,24 @@
 
 declare(strict_types=1);
 
-namespace ToshY\BunnyNet\Exception;
+namespace ToshY\BunnyNet\Exception\Validation;
 
 use Exception;
 use ToshY\BunnyNet\Enum\Type;
 
-class InvalidTypeForListValueException extends Exception
+class InvalidTypeForKeyValueException extends Exception implements BunnyValidatorExceptionInterface
 {
-    public const MESSAGE = 'Key `%s` expected list value of type `%s` got `%s` (%s).';
+    public const MESSAGE = 'Key `%s` expected value of type `%s` got `%s` (%s).';
 
-    public static function withParentKeyValueType(
-        string $parentKey,
+    public static function withKeyValueType(
+        string $key,
         Type $expectedValueType,
         mixed $actualValue,
     ): self {
         return new self(
             sprintf(
                 self::MESSAGE,
-                $parentKey,
+                $key,
                 $expectedValueType->value,
                 gettype($actualValue),
                 is_array($actualValue) === true ? json_encode($actualValue) : $actualValue,

--- a/src/Exception/Validation/InvalidTypeForListValueException.php
+++ b/src/Exception/Validation/InvalidTypeForListValueException.php
@@ -2,24 +2,24 @@
 
 declare(strict_types=1);
 
-namespace ToshY\BunnyNet\Exception;
+namespace ToshY\BunnyNet\Exception\Validation;
 
 use Exception;
 use ToshY\BunnyNet\Enum\Type;
 
-class InvalidTypeForKeyValueException extends Exception
+class InvalidTypeForListValueException extends Exception implements BunnyValidatorExceptionInterface
 {
-    public const MESSAGE = 'Key `%s` expected value of type `%s` got `%s` (%s).';
+    public const MESSAGE = 'Key `%s` expected list value of type `%s` got `%s` (%s).';
 
-    public static function withKeyValueType(
-        string $key,
+    public static function withParentKeyValueType(
+        string $parentKey,
         Type $expectedValueType,
         mixed $actualValue,
     ): self {
         return new self(
             sprintf(
                 self::MESSAGE,
-                $key,
+                $parentKey,
                 $expectedValueType->value,
                 gettype($actualValue),
                 is_array($actualValue) === true ? json_encode($actualValue) : $actualValue,

--- a/src/Exception/Validation/ParameterIsRequiredException.php
+++ b/src/Exception/Validation/ParameterIsRequiredException.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace ToshY\BunnyNet\Exception;
+namespace ToshY\BunnyNet\Exception\Validation;
 
 use Exception;
 
-class ParameterIsRequiredException extends Exception
+class ParameterIsRequiredException extends Exception implements BunnyValidatorExceptionInterface
 {
     public const MESSAGE = 'The parameter key `%s`%s is required but not provided.';
 

--- a/src/Exception/Validation/UnexpectedParameterForObjectException.php
+++ b/src/Exception/Validation/UnexpectedParameterForObjectException.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace ToshY\BunnyNet\Exception;
+namespace ToshY\BunnyNet\Exception\Validation;
 
 use Exception;
 
-class UnexpectedParameterForObjectException extends Exception
+class UnexpectedParameterForObjectException extends Exception implements BunnyValidatorExceptionInterface
 {
     public const MESSAGE = 'Unexpected parameter `%s` provided%s%s.';
 

--- a/src/LoggingAPI.php
+++ b/src/LoggingAPI.php
@@ -10,17 +10,19 @@ use ToshY\BunnyNet\Client\BunnyClient;
 use ToshY\BunnyNet\Enum\Host;
 use ToshY\BunnyNet\Model\API\Logging\GetLog;
 use ToshY\BunnyNet\Model\Client\Interface\BunnyClientResponseInterface;
-use ToshY\BunnyNet\Validator\ParameterValidator;
+use ToshY\BunnyNet\Validation\BunnyValidator;
 
 class LoggingAPI
 {
     /**
      * @param string $apiKey
      * @param BunnyClient $client
+     * @param BunnyValidator $validator
      */
     public function __construct(
         protected readonly string $apiKey,
         protected readonly BunnyClient $client,
+        protected readonly BunnyValidator $validator = new BunnyValidator(),
     ) {
         $this->client
             ->setApiKey($this->apiKey)
@@ -31,9 +33,7 @@ class LoggingAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param int $pullZoneId
      * @param DateTimeInterface $dateTime
      * @param array<string,mixed> $query
@@ -47,7 +47,7 @@ class LoggingAPI
         $endpoint = new GetLog();
         $dateTimeFormat = $dateTime->format('m-d-y');
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,

--- a/src/ShieldAPI.php
+++ b/src/ShieldAPI.php
@@ -37,17 +37,19 @@ use ToshY\BunnyNet\Model\API\Shield\Zone\GetShieldZoneByPullZoneId;
 use ToshY\BunnyNet\Model\API\Shield\Zone\ListShieldZones;
 use ToshY\BunnyNet\Model\API\Shield\Zone\UpdateShieldZone;
 use ToshY\BunnyNet\Model\Client\Interface\BunnyClientResponseInterface;
-use ToshY\BunnyNet\Validator\ParameterValidator;
+use ToshY\BunnyNet\Validation\BunnyValidator;
 
 class ShieldAPI
 {
     /**
      * @param string $apiKey
      * @param BunnyClient $client
+     * @param BunnyValidator $validator
      */
     public function __construct(
         protected readonly string $apiKey,
         protected readonly BunnyClient $client,
+        protected readonly BunnyValidator $validator = new BunnyValidator(),
     ) {
         $this->client
             ->setApiKey($this->apiKey)
@@ -57,10 +59,8 @@ class ShieldAPI
     /**
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
      * @throws Exception\JSONException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param array<string,mixed> $query
      * @return BunnyClientResponseInterface
      */
@@ -68,7 +68,7 @@ class ShieldAPI
     {
         $endpoint = new ListShieldZones();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -114,9 +114,7 @@ class ShieldAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param array<string,mixed> $body
      */
@@ -124,7 +122,7 @@ class ShieldAPI
     {
         $endpoint = new CreateShieldZone();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -136,9 +134,7 @@ class ShieldAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param array<string,mixed> $body
      */
@@ -146,7 +142,7 @@ class ShieldAPI
     {
         $endpoint = new UpdateShieldZone();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -190,9 +186,7 @@ class ShieldAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param int $shieldZoneId
      * @param array<string,mixed> $body
@@ -203,7 +197,7 @@ class ShieldAPI
     ): BunnyClientResponseInterface {
         $endpoint = new ReviewTriggeredRule();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -236,9 +230,7 @@ class ShieldAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param int $shieldZoneId
      * @param array<string,mixed> $query
      * @return BunnyClientResponseInterface
@@ -249,7 +241,7 @@ class ShieldAPI
     ): BunnyClientResponseInterface {
         $endpoint = new ListCustomWAFRules();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -279,9 +271,7 @@ class ShieldAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param int $id
      * @param array<string,mixed> $body
@@ -292,7 +282,7 @@ class ShieldAPI
     ): BunnyClientResponseInterface {
         $endpoint = new UpdateCustomWAFRule();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -305,9 +295,7 @@ class ShieldAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param int $id
      * @param array<string,mixed> $body
@@ -318,7 +306,7 @@ class ShieldAPI
     ): BunnyClientResponseInterface {
         $endpoint = new UpdateCustomWAFRuleByPatch();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -348,9 +336,7 @@ class ShieldAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param array<string,mixed> $body
      */
@@ -359,7 +345,7 @@ class ShieldAPI
     ): BunnyClientResponseInterface {
         $endpoint = new CreateCustomWAFRule();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -431,9 +417,7 @@ class ShieldAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param int $shieldZoneId
      * @param array<string,mixed> $query
      * @return BunnyClientResponseInterface
@@ -444,7 +428,7 @@ class ShieldAPI
     ): BunnyClientResponseInterface {
         $endpoint = new ListRateLimits();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -474,9 +458,7 @@ class ShieldAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param int $id
      * @param array<string,mixed> $body
@@ -487,7 +469,7 @@ class ShieldAPI
     ): BunnyClientResponseInterface {
         $endpoint = new UpdateRateLimit();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -517,9 +499,7 @@ class ShieldAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param array<string,mixed> $body
      */
@@ -528,7 +508,7 @@ class ShieldAPI
     ): BunnyClientResponseInterface {
         $endpoint = new CreateRateLimit();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,

--- a/src/StreamAPI.php
+++ b/src/StreamAPI.php
@@ -8,10 +8,10 @@ use Psr\Http\Client\ClientExceptionInterface;
 use ToshY\BunnyNet\Client\BunnyClient;
 use ToshY\BunnyNet\Enum\Host;
 use ToshY\BunnyNet\Exception\BunnyClientResponseException;
-use ToshY\BunnyNet\Exception\InvalidTypeForKeyValueException;
-use ToshY\BunnyNet\Exception\InvalidTypeForListValueException;
 use ToshY\BunnyNet\Exception\JSONException;
-use ToshY\BunnyNet\Exception\ParameterIsRequiredException;
+use ToshY\BunnyNet\Exception\Validation\BunnyValidatorExceptionInterface;
+use ToshY\BunnyNet\Exception\Validation\InvalidTypeForKeyValueException;
+use ToshY\BunnyNet\Exception\Validation\InvalidTypeForListValueException;
 use ToshY\BunnyNet\Helper\BodyContentHelper;
 use ToshY\BunnyNet\Model\API\Stream\ManageCollections\CreateCollection;
 use ToshY\BunnyNet\Model\API\Stream\ManageCollections\DeleteCollection;
@@ -20,9 +20,9 @@ use ToshY\BunnyNet\Model\API\Stream\ManageCollections\ListCollections;
 use ToshY\BunnyNet\Model\API\Stream\ManageCollections\UpdateCollection;
 use ToshY\BunnyNet\Model\API\Stream\ManageVideos\AddCaption;
 use ToshY\BunnyNet\Model\API\Stream\ManageVideos\AddOutputCodecToVideo;
-use ToshY\BunnyNet\Model\API\Stream\ManageVideos\DeleteUnconfiguredResolutions;
 use ToshY\BunnyNet\Model\API\Stream\ManageVideos\CreateVideo;
 use ToshY\BunnyNet\Model\API\Stream\ManageVideos\DeleteCaption;
+use ToshY\BunnyNet\Model\API\Stream\ManageVideos\DeleteUnconfiguredResolutions;
 use ToshY\BunnyNet\Model\API\Stream\ManageVideos\DeleteVideo;
 use ToshY\BunnyNet\Model\API\Stream\ManageVideos\FetchVideo;
 use ToshY\BunnyNet\Model\API\Stream\ManageVideos\GetVideo;
@@ -39,17 +39,19 @@ use ToshY\BunnyNet\Model\API\Stream\ManageVideos\UpdateVideo;
 use ToshY\BunnyNet\Model\API\Stream\ManageVideos\UploadVideo;
 use ToshY\BunnyNet\Model\API\Stream\OEmbed\GetOEmbed;
 use ToshY\BunnyNet\Model\Client\Interface\BunnyClientResponseInterface;
-use ToshY\BunnyNet\Validator\ParameterValidator;
+use ToshY\BunnyNet\Validation\BunnyValidator;
 
 class StreamAPI
 {
     /**
      * @param string $apiKey
      * @param BunnyClient $client
+     * @param BunnyValidator $validator
      */
     public function __construct(
         protected readonly string $apiKey,
         protected readonly BunnyClient $client,
+        protected readonly BunnyValidator $validator = new BunnyValidator(),
     ) {
         $this->client
             ->setApiKey($this->apiKey)
@@ -60,9 +62,7 @@ class StreamAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param string $collectionId
      * @param array<string,mixed> $query
      * @return BunnyClientResponseInterface
@@ -75,7 +75,7 @@ class StreamAPI
     ): BunnyClientResponseInterface {
         $endpoint = new GetCollection();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -88,9 +88,7 @@ class StreamAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param string $collectionId
      * @param array<string,mixed> $body
      * @return BunnyClientResponseInterface
@@ -103,7 +101,7 @@ class StreamAPI
     ): BunnyClientResponseInterface {
         $endpoint = new UpdateCollection();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -136,9 +134,7 @@ class StreamAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param array<string,mixed> $query
      * @return BunnyClientResponseInterface
      * @param int $libraryId
@@ -149,7 +145,7 @@ class StreamAPI
     ): BunnyClientResponseInterface {
         $endpoint = new ListCollections();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -162,9 +158,7 @@ class StreamAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param int $libraryId
      * @param array<string,mixed> $body
@@ -175,7 +169,7 @@ class StreamAPI
     ): BunnyClientResponseInterface {
         $endpoint = new CreateCollection();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -208,9 +202,7 @@ class StreamAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param string $videoId
      * @param array<string,mixed> $body
      * @return BunnyClientResponseInterface
@@ -223,7 +215,7 @@ class StreamAPI
     ): BunnyClientResponseInterface {
         $endpoint = new UpdateVideo();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -256,9 +248,7 @@ class StreamAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @return BunnyClientResponseInterface
      * @param int $libraryId
      * @param array<string,mixed> $body
@@ -269,7 +259,7 @@ class StreamAPI
     ): BunnyClientResponseInterface {
         $endpoint = new CreateVideo();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -282,9 +272,7 @@ class StreamAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param int $libraryId
      * @param string $videoId
      * @param mixed $body
@@ -299,7 +287,7 @@ class StreamAPI
     ): BunnyClientResponseInterface {
         $endpoint = new UploadVideo();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -335,7 +323,7 @@ class StreamAPI
      * @throws InvalidTypeForKeyValueException
      * @throws InvalidTypeForListValueException
      * @throws JSONException
-     * @throws ParameterIsRequiredException
+     * @throws BunnyValidatorExceptionInterface
      * @param int $libraryId
      * @param string $videoId
      * @param array<string,mixed> $query
@@ -348,7 +336,7 @@ class StreamAPI
     ): BunnyClientResponseInterface {
         $endpoint = new GetVideoPlayData();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -361,9 +349,7 @@ class StreamAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param array<string,mixed> $query
      * @return BunnyClientResponseInterface
      * @param int $libraryId
@@ -374,7 +360,7 @@ class StreamAPI
     ): BunnyClientResponseInterface {
         $endpoint = new ListVideoStatistics();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -431,7 +417,7 @@ class StreamAPI
      * @throws InvalidTypeForKeyValueException
      * @throws InvalidTypeForListValueException
      * @throws JSONException
-     * @throws ParameterIsRequiredException
+     * @throws BunnyValidatorExceptionInterface
      * @param int $libraryId
      * @param string $videoId
      * @param array<string,mixed> $query
@@ -444,7 +430,7 @@ class StreamAPI
     ): BunnyClientResponseInterface {
         $endpoint = new RepackageVideo();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -457,9 +443,7 @@ class StreamAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param array<string,mixed> $query
      * @return BunnyClientResponseInterface
      * @param int $libraryId
@@ -470,7 +454,7 @@ class StreamAPI
     ): BunnyClientResponseInterface {
         $endpoint = new ListVideos();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -483,9 +467,7 @@ class StreamAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param int $libraryId
      * @param string $videoId
      * @param array<string,mixed> $query
@@ -498,7 +480,7 @@ class StreamAPI
     ): BunnyClientResponseInterface {
         $endpoint = new SetThumbnail();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -511,9 +493,7 @@ class StreamAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param array<string,mixed> $body
      * @param array<string,mixed> $query
      * @return BunnyClientResponseInterface
@@ -526,8 +506,8 @@ class StreamAPI
     ): BunnyClientResponseInterface {
         $endpoint = new FetchVideo();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->query($query, $endpoint);
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -541,9 +521,7 @@ class StreamAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param int $libraryId
      * @param string $videoId
      * @param string $sourceLanguage
@@ -558,7 +536,7 @@ class StreamAPI
     ): BunnyClientResponseInterface {
         $endpoint = new AddCaption();
 
-        ParameterValidator::validate($body, $endpoint->getBody());
+        $this->validator->body($body, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -593,9 +571,7 @@ class StreamAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param int $libraryId
      * @param string $videoId
      * @param array<string,mixed> $query
@@ -608,7 +584,7 @@ class StreamAPI
     ): BunnyClientResponseInterface {
         $endpoint = new TranscribeVideo();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -641,9 +617,7 @@ class StreamAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param int $libraryId
      * @param string $videoId
      * @param array<string,mixed> $query
@@ -656,7 +630,7 @@ class StreamAPI
     ): BunnyClientResponseInterface {
         $endpoint = new DeleteUnconfiguredResolutions();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,
@@ -669,9 +643,7 @@ class StreamAPI
      * @throws ClientExceptionInterface
      * @throws Exception\BunnyClientResponseException
      * @throws Exception\JSONException
-     * @throws Exception\InvalidTypeForKeyValueException
-     * @throws Exception\InvalidTypeForListValueException
-     * @throws Exception\ParameterIsRequiredException
+     * @throws Exception\Validation\BunnyValidatorExceptionInterface
      * @param array<string,mixed> $query
      * @return BunnyClientResponseInterface
      */
@@ -680,7 +652,7 @@ class StreamAPI
     ): BunnyClientResponseInterface {
         $endpoint = new GetOEmbed();
 
-        ParameterValidator::validate($query, $endpoint->getQuery());
+        $this->validator->query($query, $endpoint);
 
         return $this->client->request(
             endpoint: $endpoint,

--- a/src/Validation/BunnyValidator.php
+++ b/src/Validation/BunnyValidator.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ToshY\BunnyNet\Validation;
+
+use ToshY\BunnyNet\Enum\ValidationType;
+use ToshY\BunnyNet\Enum\ModelStrategy;
+use ToshY\BunnyNet\Exception\Validation\BunnyValidatorExceptionInterface;
+use ToshY\BunnyNet\Model\EndpointBodyInterface;
+use ToshY\BunnyNet\Model\EndpointQueryInterface;
+
+class BunnyValidator
+{
+    /** @var array<class-string,ModelStrategy> $modelStrategy */
+    private array $modelStrategy;
+
+    /**
+     * @param array<class-string,ModelStrategy> $modelStrategyOverride
+     */
+    public function __construct(
+        ValidationType $validationType = ValidationType::MODEL,
+        array $modelStrategyOverride = [],
+    ) {
+        $this->modelStrategy = $validationType->getStrategy($modelStrategyOverride);
+    }
+
+    /**
+     * @throws BunnyValidatorExceptionInterface
+     * @param array<string,mixed> $values
+     * @param EndpointQueryInterface $endpoint
+     * @return void
+     */
+    public function query(
+        array $values,
+        EndpointQueryInterface $endpoint,
+    ): void {
+        $hasModelStrategy = isset($this->modelStrategy[$endpoint::class]) === true;
+        if ($hasModelStrategy === false) {
+            return;
+        }
+
+        /** @var ModelStrategy $modelStrategy */
+        $modelStrategy = $this->modelStrategy[$endpoint::class];
+        $queryStrategy = $modelStrategy->validationStrategy()->query;
+
+        $queryStrategy::validate($values, $endpoint);
+    }
+
+    /**
+     * @throws BunnyValidatorExceptionInterface
+     * @param array<string,mixed> $values
+     * @param EndpointBodyInterface $endpoint
+     * @return void
+     */
+    public function body(
+        mixed $values,
+        EndpointBodyInterface $endpoint,
+    ): void {
+        $hasModelStrategy = isset($this->modelStrategy[$endpoint::class]) === true;
+        if ($hasModelStrategy === false) {
+            return;
+        }
+
+        /** @var ModelStrategy $modelStrategy */
+        $modelStrategy = $this->modelStrategy[$endpoint::class];
+        $bodyStrategy = $modelStrategy->validationStrategy()->body;
+
+        $bodyStrategy::validate($values, $endpoint);
+    }
+}

--- a/src/Validation/ParameterValidator.php
+++ b/src/Validation/ParameterValidator.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace ToshY\BunnyNet\Validator;
+namespace ToshY\BunnyNet\Validation;
 
 use ToshY\BunnyNet\Enum\Type;
-use ToshY\BunnyNet\Exception\InvalidTypeForKeyValueException;
-use ToshY\BunnyNet\Exception\InvalidTypeForListValueException;
-use ToshY\BunnyNet\Exception\ParameterIsRequiredException;
-use ToshY\BunnyNet\Exception\UnexpectedParameterForObjectException;
+use ToshY\BunnyNet\Exception\Validation\InvalidTypeForKeyValueException;
+use ToshY\BunnyNet\Exception\Validation\InvalidTypeForListValueException;
+use ToshY\BunnyNet\Exception\Validation\ParameterIsRequiredException;
+use ToshY\BunnyNet\Exception\Validation\UnexpectedParameterForObjectException;
 use ToshY\BunnyNet\Model\AbstractParameter;
 
 class ParameterValidator

--- a/src/Validation/Strategy/Body/BodyValidationStrategyInterface.php
+++ b/src/Validation/Strategy/Body/BodyValidationStrategyInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ToshY\BunnyNet\Validation\Strategy\Body;
+
+use ToshY\BunnyNet\Exception\Validation\BunnyValidatorExceptionInterface;
+use ToshY\BunnyNet\Model\EndpointBodyInterface;
+
+interface BodyValidationStrategyInterface
+{
+    /**
+     * @throws BunnyValidatorExceptionInterface
+     * @param array<string,mixed> $values
+     */
+    public static function validate(array $values, EndpointBodyInterface $endpoint): void;
+}

--- a/src/Validation/Strategy/Body/LaxBodyValidationStrategy.php
+++ b/src/Validation/Strategy/Body/LaxBodyValidationStrategy.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ToshY\BunnyNet\Validation\Strategy\Body;
+
+use ToshY\BunnyNet\Exception\Validation\UnexpectedParameterForObjectException;
+use ToshY\BunnyNet\Model\EndpointBodyInterface;
+use ToshY\BunnyNet\Validation\ParameterValidator;
+
+class LaxBodyValidationStrategy implements BodyValidationStrategyInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public static function validate(array $values, EndpointBodyInterface $endpoint): void
+    {
+        try {
+            ParameterValidator::validate($values, $endpoint->getBody());
+        } catch (UnexpectedParameterForObjectException) {
+            return;
+        }
+    }
+}

--- a/src/Validation/Strategy/Body/NoBodyValidationStrategy.php
+++ b/src/Validation/Strategy/Body/NoBodyValidationStrategy.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ToshY\BunnyNet\Validation\Strategy\Body;
+
+use ToshY\BunnyNet\Model\EndpointBodyInterface;
+
+class NoBodyValidationStrategy implements BodyValidationStrategyInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public static function validate(array $values, EndpointBodyInterface $endpoint): void
+    {
+    }
+}

--- a/src/Validation/Strategy/Body/StrictBodyValidationStrategy.php
+++ b/src/Validation/Strategy/Body/StrictBodyValidationStrategy.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ToshY\BunnyNet\Validation\Strategy\Body;
+
+use ToshY\BunnyNet\Model\EndpointBodyInterface;
+use ToshY\BunnyNet\Validation\ParameterValidator;
+
+class StrictBodyValidationStrategy implements BodyValidationStrategyInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public static function validate(array $values, EndpointBodyInterface $endpoint): void
+    {
+        ParameterValidator::validate($values, $endpoint->getBody());
+    }
+}

--- a/src/Validation/Strategy/Query/LaxQueryValidationStrategy.php
+++ b/src/Validation/Strategy/Query/LaxQueryValidationStrategy.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ToshY\BunnyNet\Validation\Strategy\Query;
+
+use ToshY\BunnyNet\Exception\Validation\UnexpectedParameterForObjectException;
+use ToshY\BunnyNet\Model\EndpointQueryInterface;
+use ToshY\BunnyNet\Validation\ParameterValidator;
+
+class LaxQueryValidationStrategy implements QueryValidationStrategyInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public static function validate(array $values, EndpointQueryInterface $endpoint): void
+    {
+        try {
+            ParameterValidator::validate($values, $endpoint->getQuery());
+        } catch (UnexpectedParameterForObjectException) {
+            return;
+        }
+    }
+}

--- a/src/Validation/Strategy/Query/NoQueryValidationStrategy.php
+++ b/src/Validation/Strategy/Query/NoQueryValidationStrategy.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ToshY\BunnyNet\Validation\Strategy\Query;
+
+use ToshY\BunnyNet\Model\EndpointQueryInterface;
+
+class NoQueryValidationStrategy implements QueryValidationStrategyInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public static function validate(array $values, EndpointQueryInterface $endpoint): void
+    {
+    }
+}

--- a/src/Validation/Strategy/Query/QueryValidationStrategyInterface.php
+++ b/src/Validation/Strategy/Query/QueryValidationStrategyInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ToshY\BunnyNet\Validation\Strategy\Query;
+
+use ToshY\BunnyNet\Exception\Validation\BunnyValidatorExceptionInterface;
+use ToshY\BunnyNet\Model\EndpointQueryInterface;
+
+interface QueryValidationStrategyInterface
+{
+    /**
+     * @throws BunnyValidatorExceptionInterface
+     * @param array<string,mixed> $values
+     */
+    public static function validate(array $values, EndpointQueryInterface $endpoint): void;
+}

--- a/src/Validation/Strategy/Query/StrictQueryValidationStrategy.php
+++ b/src/Validation/Strategy/Query/StrictQueryValidationStrategy.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ToshY\BunnyNet\Validation\Strategy\Query;
+
+use ToshY\BunnyNet\Model\EndpointQueryInterface;
+use ToshY\BunnyNet\Validation\ParameterValidator;
+
+class StrictQueryValidationStrategy implements QueryValidationStrategyInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public static function validate(array $values, EndpointQueryInterface $endpoint): void
+    {
+        ParameterValidator::validate($values, $endpoint->getQuery());
+    }
+}

--- a/src/Validation/Strategy/ValidationModelStrategy.php
+++ b/src/Validation/Strategy/ValidationModelStrategy.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ToshY\BunnyNet\Validation\Strategy;
+
+use ToshY\BunnyNet\Validation\Strategy\Body\BodyValidationStrategyInterface;
+use ToshY\BunnyNet\Validation\Strategy\Query\QueryValidationStrategyInterface;
+
+/**
+ * @internal
+ */
+final class ValidationModelStrategy
+{
+    public function __construct(
+        public readonly QueryValidationStrategyInterface $query,
+        public readonly BodyValidationStrategyInterface $body,
+    ) {
+    }
+}

--- a/tests/Validator/ParameterValidatorTest.php
+++ b/tests/Validator/ParameterValidatorTest.php
@@ -6,12 +6,12 @@ namespace ToshY\BunnyNet\Tests\Validator;
 
 use PHPUnit\Framework\TestCase;
 use ToshY\BunnyNet\Enum\Type;
-use ToshY\BunnyNet\Exception\InvalidTypeForKeyValueException;
-use ToshY\BunnyNet\Exception\InvalidTypeForListValueException;
-use ToshY\BunnyNet\Exception\ParameterIsRequiredException;
-use ToshY\BunnyNet\Exception\UnexpectedParameterForObjectException;
+use ToshY\BunnyNet\Exception\Validation\InvalidTypeForKeyValueException;
+use ToshY\BunnyNet\Exception\Validation\InvalidTypeForListValueException;
+use ToshY\BunnyNet\Exception\Validation\ParameterIsRequiredException;
+use ToshY\BunnyNet\Exception\Validation\UnexpectedParameterForObjectException;
 use ToshY\BunnyNet\Model\AbstractParameter;
-use ToshY\BunnyNet\Validator\ParameterValidator;
+use ToshY\BunnyNet\Validation\ParameterValidator;
 
 class ParameterValidatorTest extends TestCase
 {


### PR DESCRIPTION
Fixes #160 

---

Introduces a new `BunnyValidator` argument to the API classes.

**Thought process**

While the simplest "solution" would be creating a "simple" boolean toggle to just enable/disable the complete validation, I found this a bit "akward" to do. I could add a boolean to  the API classes as an argument, but then I would have add if-checks to check if the boolean was true and validate if necessary, this makes the public methods more messey than needs to be. Another idea would to pass the boolean to the `BunnyClient` instead, and maybe shift the validation from the API methods to the `BunnyClient` directly. This would make it more centralized as validation could occur inside the `request` method. However, I do not think it's the responsibility of the `BunnyClient` to validate, so I refrained from going down that path.

At some point when messing around with this, I realised that there could be more fine-grained control if the validation could be enabled/disabled on model level, not just globally. By doing so, users could enable/disable either query and/or body parameter validation for each model individually if they want. 

Now I got the idea for a flexible implementation: create a type for the validator itself to enable/disable validation globally, and create "strategies" for validating query and body parameters for individual model validation. That way users have the flexibility to completely disable the parameter validation, or disable validation for specific models, by just plugging in a custom `BunnyClient` into the API class.

**Examples**

Test feature branch

```shell
composer require toshy/bunnynet-php:dev-feature/160
```

_Default (backwards-compatible)_

```php
<?php

require 'vendor/autoload.php';

use ToshY\BunnyNet\BaseAPI;
use ToshY\BunnyNet\Client\BunnyClient;

$bunnyClient = new BunnyClient(
    client: new \Symfony\Component\HttpClient\Psr18Client(),
);

// Provide the account API key.
$baseApi = new BaseAPI(
    apiKey: '2cebf4f8-4bff-429f-86f6-bce2c2163d7e89fb0a86-a1b2-463c-a142-11eba8811989',
    client: $bunnyClient, 
    // the last argument is the validator defaulting to the standard `BunnyValidator`
);
```

_Disable validation - globally_

```php
<?php

require 'vendor/autoload.php';

use ToshY\BunnyNet\BaseAPI;
use ToshY\BunnyNet\Client\BunnyClient;
use ToshY\BunnyNet\Enum\ValidationType;
use ToshY\BunnyNet\Validation\BunnyValidator;

$bunnyClient = new BunnyClient(
    client: new \Symfony\Component\HttpClient\Psr18Client(),
);

// Globally disable parameter validation by defining ValidatorStrategy::NONE
$bunnyValidator = new BunnyValidator(
    validationType: ValidationType::NONE
);

// Provide the account API key.
$baseApi = new BaseAPI(
    apiKey: '2cebf4f8-4bff-429f-86f6-bce2c2163d7e89fb0a86-a1b2-463c-a142-11eba8811989',
    client: $bunnyClient,
    validator: $bunnyValidator
);
```

_Disable validation - model_

```php
<?php

require 'vendor/autoload.php';

use ToshY\BunnyNet\BaseAPI;
use ToshY\BunnyNet\Client\BunnyClient;
use ToshY\BunnyNet\Enum\ModelStrategy;
use ToshY\BunnyNet\Enum\ValidationType;
use ToshY\BunnyNet\Model\API\Base\DNSZone\AddDNSRecord;
use ToshY\BunnyNet\Validation\BunnyValidator;

$bunnyClient = new BunnyClient(
    client: new \Symfony\Component\HttpClient\Psr18Client(),
);

// Disable validation for a specific model by overriding the ModelStrategy
$bunnyValidator = new BunnyValidator(
    validationType: ValidationType::MODEL // this is the default value so it can be omitted
    modelStrategyOverride: [
        AddDNSRecord::class => ModelStrategy::NONE,
    ]
);

// Provide the account API key.
$baseApi = new BaseAPI(
    apiKey: '2cebf4f8-4bff-429f-86f6-bce2c2163d7e89fb0a86-a1b2-463c-a142-11eba8811989',
    client: $bunnyClient,
    validator: $bunnyValidator
);
```

---

**Afterthought**

I still have lingering doubts that the validator should/might not be necessary to have in the library. The valdation of query/body request parameters should be the responsibility of the API, not the library. For now, the only upside I see for it is that it prevents unnecessary API requests by pre-validating in case the query/body parameters supplied by the user were incorrect. This is useful for testing/development purposes, but I don't know if there are more use cases for it.

For now the validator is kept and it is flexible enough to disable entirely, or disable validation for query/body parameters per model. 

Maybe in a future (major/minor) release I will reconsider and remove the validation entirely.