### PR TITLE
Patch/automated models 71e32c8 fixed

### DIFF
--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Run model generator
         run: php generator/Command/generate-models.php --log
 
+      - name: Run map generator for possible newly created models
+        run: php generator/Command/generate-maps.php
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7.0.8
         id: cpr

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -80,6 +80,13 @@ tasks:
     cmds:
       - docker compose run --rm $TTY php php /app/generator/Command/generate-models.php {{.CLI_ARGS | default "--log"}}
 
+  specs:
+    desc: Run maps and models generators
+    cmds:
+      - task: specs:maps
+      - task: specs:models
+      - task: specs:maps
+
   # Git
   git:hooks:
     desc: Setup git hooks

--- a/docs/base-api.md
+++ b/docs/base-api.md
@@ -597,6 +597,20 @@ $bunnyHttpClient->request(
 );
 ```
 
+#### [Get Video Library DRM Statistics](https://docs.bunny.net/reference/getdrmstatisticsendpoint_statistics)
+
+```php
+$bunnyHttpClient->request(
+    new \ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\GetDrmStatistics(
+        id: 1,
+        query: [
+            'dateFrom' => 'm-d-Y',
+            'dateTo' => 'm-d-Y',
+        ],
+    )
+);
+```
+
 #### [Get Languages](https://docs.bunny.net/reference/videolibrarypublic_index3)
 
 ```php

--- a/docs/stream-api.md
+++ b/docs/stream-api.md
@@ -244,6 +244,21 @@ $bunnyHttpClient->request(
     ```
     A support ticket has been created at bunny.net regarding this issue.
 
+#### [Get Video Heatmap Data](https://docs.bunny.net/reference/video_getvideoheatmapdata)
+
+```php
+$bunnyHttpClient->request(
+    new \ToshY\BunnyNet\Model\Api\Stream\ManageVideos\GetVideoHeatmapData(
+        libraryId: 1,
+        videoId: 'e7e9b99a-ea2a-434a-b200-f6615e7b6abd',
+        query: [
+            'token' => 'ead85f9a-578b-42b7-985f-9a578b12b776',
+            'expires' => 3600,
+        ],
+    )
+);
+```
+
 #### [Get Video Play Data](https://docs.bunny.net/reference/video_getvideoplaydata)
 
 ```php
@@ -443,7 +458,6 @@ $bunnyHttpClient->request(
         libraryId: 1,
         videoId: 'e7e9b99a-ea2a-434a-b200-f6615e7b6abd',
         query: [
-            'language' => 'fi',
             'force' => true,
         ],
         body: [
@@ -461,7 +475,7 @@ $bunnyHttpClient->request(
 
 !!! note
 
-    - The `language` is a [two-letter (set 1) language abbreviation](https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes) for transcribing the video.
+    - The `targetLanguages` / `sourceLanguage` require a [two-letter (set 1) language abbreviation](https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes) for transcribing the video.
     - Once a video has transcribed you need to set `force` to `true` in order to force a new transcription to be added.
     - The body parameter `sourceLanguage` takes precedence over the query parameter `language`.
 

--- a/generator/Map/Base.php
+++ b/generator/Map/Base.php
@@ -89,6 +89,7 @@ use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\AddVideoLibrary;
 use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\AddWatermark;
 use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\DeleteVideoLibrary;
 use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\DeleteWatermark;
+use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\GetDrmStatistics;
 use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\GetLanguages;
 use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\GetVideoLibrary;
 use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\ListVideoLibraries;
@@ -248,6 +249,9 @@ final class Base
         ],
         '/videolibrary/{id}/removeBlockedReferrer' => [
             'post' => RemoveBlockedReferer::class,
+        ],
+        '/videolibrary/{id}/drm/statistics' => [
+            'get' => GetDrmStatistics::class,
         ],
         '/dnszone' => [
             'get' => ListDnsZones::class,

--- a/generator/Map/Stream.php
+++ b/generator/Map/Stream.php
@@ -18,6 +18,7 @@ use ToshY\BunnyNet\Model\Api\Stream\ManageVideos\DeleteVideo;
 use ToshY\BunnyNet\Model\Api\Stream\ManageVideos\FetchVideo;
 use ToshY\BunnyNet\Model\Api\Stream\ManageVideos\GetVideo;
 use ToshY\BunnyNet\Model\Api\Stream\ManageVideos\GetVideoHeatmap;
+use ToshY\BunnyNet\Model\Api\Stream\ManageVideos\GetVideoHeatmapData;
 use ToshY\BunnyNet\Model\Api\Stream\ManageVideos\GetVideoPlayData;
 use ToshY\BunnyNet\Model\Api\Stream\ManageVideos\GetVideoStatistics;
 use ToshY\BunnyNet\Model\Api\Stream\ManageVideos\ListVideos;
@@ -57,6 +58,9 @@ final class Stream
         ],
         '/library/{libraryId}/videos/{videoId}/play' => [
             'get' => GetVideoPlayData::class,
+        ],
+        '/library/{libraryId}/videos/{videoId}/play/heatmap' => [
+            'get' => GetVideoHeatmapData::class,
         ],
         '/library/{libraryId}/statistics' => [
             'get' => GetVideoStatistics::class,

--- a/generator/Utils/ClassUtils.php
+++ b/generator/Utils/ClassUtils.php
@@ -102,4 +102,19 @@ final class ClassUtils
     {
         return str_replace('/', '\\', $path);
     }
+
+
+    public static function toPascalCase(string $text, string $textDelimiter = ' '): string
+    {
+        return implode(
+            '',
+            array_map(
+                function ($v) {
+                    $v = strtolower($v);
+                    return ucfirst($v);
+                },
+                explode(separator: $textDelimiter, string: $text),
+            ),
+        );
+    }
 }

--- a/generator/Utils/OpenApiModelUtils.php
+++ b/generator/Utils/OpenApiModelUtils.php
@@ -27,7 +27,7 @@ final class OpenApiModelUtils
      * @param array<string> $tags
      * @return string
      */
-    public static function stripTagSuffix(string $value, array $tags = ['Public', 'Index']): string
+    public static function stripTagSuffix(string $value, array $tags = ['Public', 'Index', 'Endpoint']): string
     {
         return preg_replace(
             sprintf(
@@ -37,5 +37,18 @@ final class OpenApiModelUtils
             '',
             $value,
         );
+    }
+
+    /**
+     * @param string[] $tags
+     */
+    public static function extractNamespaceFromTags(array $tags): ?string
+    {
+        if (empty($tags) === true) {
+            return null;
+        }
+
+        // The first tag has priority over other tags in case there are multiple.
+        return $tags[0];
     }
 }

--- a/src/Enum/Validation/Map/Base.php
+++ b/src/Enum/Validation/Map/Base.php
@@ -91,6 +91,7 @@ use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\AddVideoLibrary;
 use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\AddWatermark;
 use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\DeleteVideoLibrary;
 use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\DeleteWatermark;
+use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\GetDrmStatistics;
 use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\GetLanguages;
 use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\GetVideoLibrary;
 use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\ListVideoLibraries;
@@ -170,6 +171,7 @@ final class Base
         RemoveAllowedReferer::class => ModelValidationStrategy::STRICT_BODY,
         AddBlockedReferer::class => ModelValidationStrategy::STRICT_BODY,
         RemoveBlockedReferer::class => ModelValidationStrategy::STRICT_BODY,
+        GetDrmStatistics::class => ModelValidationStrategy::STRICT_QUERY,
         ListDnsZones::class => ModelValidationStrategy::STRICT_QUERY,
         AddDnsZone::class => ModelValidationStrategy::STRICT_BODY,
         GetDnsZone::class => ModelValidationStrategy::NONE,

--- a/src/Enum/Validation/Map/Stream.php
+++ b/src/Enum/Validation/Map/Stream.php
@@ -19,6 +19,7 @@ use ToshY\BunnyNet\Model\Api\Stream\ManageVideos\DeleteVideo;
 use ToshY\BunnyNet\Model\Api\Stream\ManageVideos\FetchVideo;
 use ToshY\BunnyNet\Model\Api\Stream\ManageVideos\GetVideo;
 use ToshY\BunnyNet\Model\Api\Stream\ManageVideos\GetVideoHeatmap;
+use ToshY\BunnyNet\Model\Api\Stream\ManageVideos\GetVideoHeatmapData;
 use ToshY\BunnyNet\Model\Api\Stream\ManageVideos\GetVideoPlayData;
 use ToshY\BunnyNet\Model\Api\Stream\ManageVideos\GetVideoStatistics;
 use ToshY\BunnyNet\Model\Api\Stream\ManageVideos\ListVideos;
@@ -46,6 +47,7 @@ final class Stream
         DeleteVideo::class => ModelValidationStrategy::NONE,
         GetVideoHeatmap::class => ModelValidationStrategy::NONE,
         GetVideoPlayData::class => ModelValidationStrategy::STRICT_QUERY,
+        GetVideoHeatmapData::class => ModelValidationStrategy::STRICT_QUERY,
         GetVideoStatistics::class => ModelValidationStrategy::STRICT_QUERY,
         ReEncodeVideo::class => ModelValidationStrategy::NONE,
         AddOutputCodecToVideo::class => ModelValidationStrategy::NONE,

--- a/src/Model/Api/Base/StreamVideoLibrary/GetDrmStatistics.php
+++ b/src/Model/Api/Base/StreamVideoLibrary/GetDrmStatistics.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary;
+
+use ToshY\BunnyNet\Attributes\PathProperty;
+use ToshY\BunnyNet\Attributes\QueryProperty;
+use ToshY\BunnyNet\Enum\Header;
+use ToshY\BunnyNet\Enum\Method;
+use ToshY\BunnyNet\Enum\Type;
+use ToshY\BunnyNet\Model\AbstractParameter;
+use ToshY\BunnyNet\Model\ModelInterface;
+use ToshY\BunnyNet\Model\QueryModelInterface;
+
+class GetDrmStatistics implements ModelInterface, QueryModelInterface
+{
+    /**
+     * @param int $id
+     * @param array<string,mixed> $query
+     */
+    public function __construct(
+        #[PathProperty]
+        public readonly int $id,
+        #[QueryProperty]
+        public readonly array $query = [],
+    ) {
+    }
+
+    public function getMethod(): Method
+    {
+        return Method::GET;
+    }
+
+    public function getPath(): string
+    {
+        return 'videolibrary/%d/drm/statistics';
+    }
+
+    public function getHeaders(): array
+    {
+        return [
+            Header::ACCEPT_JSON,
+        ];
+    }
+
+    public function getQuery(): array
+    {
+        return [
+            new AbstractParameter(name: 'dateFrom', type: Type::STRING_TYPE),
+            new AbstractParameter(name: 'dateTo', type: Type::STRING_TYPE),
+        ];
+    }
+}

--- a/src/Model/Api/Stream/ManageVideos/GetVideoHeatmapData.php
+++ b/src/Model/Api/Stream/ManageVideos/GetVideoHeatmapData.php
@@ -4,24 +4,21 @@ declare(strict_types=1);
 
 namespace ToshY\BunnyNet\Model\Api\Stream\ManageVideos;
 
-use ToshY\BunnyNet\Attributes\BodyProperty;
 use ToshY\BunnyNet\Attributes\PathProperty;
 use ToshY\BunnyNet\Attributes\QueryProperty;
 use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Enum\Type;
 use ToshY\BunnyNet\Model\AbstractParameter;
-use ToshY\BunnyNet\Model\BodyModelInterface;
 use ToshY\BunnyNet\Model\ModelInterface;
 use ToshY\BunnyNet\Model\QueryModelInterface;
 
-class TranscribeVideo implements ModelInterface, QueryModelInterface, BodyModelInterface
+class GetVideoHeatmapData implements ModelInterface, QueryModelInterface
 {
     /**
      * @param int $libraryId
      * @param string $videoId
      * @param array<string,mixed> $query
-     * @param array<string,mixed> $body
      */
     public function __construct(
         #[PathProperty]
@@ -30,45 +27,31 @@ class TranscribeVideo implements ModelInterface, QueryModelInterface, BodyModelI
         public readonly string $videoId,
         #[QueryProperty]
         public readonly array $query = [],
-        #[BodyProperty]
-        public readonly array $body = [],
     ) {
     }
 
     public function getMethod(): Method
     {
-        return Method::POST;
+        return Method::GET;
     }
 
     public function getPath(): string
     {
-        return 'library/%d/videos/%s/transcribe';
+        return 'library/%d/videos/%s/play/heatmap';
     }
 
     public function getHeaders(): array
     {
         return [
             Header::ACCEPT_JSON,
-            Header::CONTENT_TYPE_JSON,
         ];
     }
 
     public function getQuery(): array
     {
         return [
-            new AbstractParameter(name: 'force', type: Type::BOOLEAN_TYPE),
-        ];
-    }
-
-    public function getBody(): array
-    {
-        return [
-            new AbstractParameter(name: 'targetLanguages', type: Type::ARRAY_TYPE, children: [
-                new AbstractParameter(name: null, type: Type::STRING_TYPE),
-            ]),
-            new AbstractParameter(name: 'generateTitle', type: Type::BOOLEAN_TYPE),
-            new AbstractParameter(name: 'generateDescription', type: Type::BOOLEAN_TYPE),
-            new AbstractParameter(name: 'sourceLanguage', type: Type::STRING_TYPE),
+            new AbstractParameter(name: 'token', type: Type::STRING_TYPE),
+            new AbstractParameter(name: 'expires', type: Type::INT_TYPE),
         ];
     }
 }


### PR DESCRIPTION
Closes #173 

---

Fixes comments https://github.com/ToshY/BunnyNet-PHP/pull/173#discussion_r2263727458 due to incorrect namespace being used. Now uses the first tags on the OpenAPI specs for the endpoint instead.

Also the CI now runs the mapper again after model generation to update the map files with the endpoint classes.