### PR TITLE
[generator] keep undocumentend working OpenAPI endpoints

### DIFF
--- a/generator/Command/generate-maps.php
+++ b/generator/Command/generate-maps.php
@@ -4,6 +4,54 @@ declare(strict_types=1);
 
 use ToshY\BunnyNet\Generator\Generator\MapGenerator;
 use ToshY\BunnyNet\Generator\Utils\FileUtils;
+use ToshY\BunnyNet\Model\Api\Base\AbuseCase\CheckAbuseCase;
+use ToshY\BunnyNet\Model\Api\Base\AbuseCase\GetAbuseCase;
+use ToshY\BunnyNet\Model\Api\Base\AbuseCase\GetDmcaCase;
+use ToshY\BunnyNet\Model\Api\Base\AbuseCase\ListAbuseCases;
+use ToshY\BunnyNet\Model\Api\Base\AbuseCase\ResolveAbuseCase;
+use ToshY\BunnyNet\Model\Api\Base\AbuseCase\ResolveDmcaCase;
+use ToshY\BunnyNet\Model\Api\Base\Auth\AuthJwt2fa;
+use ToshY\BunnyNet\Model\Api\Base\Auth\RefreshJwt;
+use ToshY\BunnyNet\Model\Api\Base\Billing\ApplyPromoCode;
+use ToshY\BunnyNet\Model\Api\Base\Billing\ClaimAffiliateCredits;
+use ToshY\BunnyNet\Model\Api\Base\Billing\ConfigureAutoRecharge;
+use ToshY\BunnyNet\Model\Api\Base\Billing\CreateCoinifyPayment;
+use ToshY\BunnyNet\Model\Api\Base\Billing\CreatePaymentCheckout;
+use ToshY\BunnyNet\Model\Api\Base\Billing\GetAffiliateDetails;
+use ToshY\BunnyNet\Model\Api\Base\Billing\GetBillingDetails;
+use ToshY\BunnyNet\Model\Api\Base\Billing\GetBillingSummary;
+use ToshY\BunnyNet\Model\Api\Base\Billing\GetBillingSummaryPDF;
+use ToshY\BunnyNet\Model\Api\Base\Billing\GetCoinifyBitcoinExchangeRate;
+use ToshY\BunnyNet\Model\Api\Base\Billing\PreparePaymentAuthorization;
+use ToshY\BunnyNet\Model\Api\Base\DnsZone\DismissDnsConfigurationNotice;
+use ToshY\BunnyNet\Model\Api\Base\DnsZone\RecheckDnsConfiguration;
+use ToshY\BunnyNet\Model\Api\Base\DrmCertificate\ListDrmCertificates;
+use ToshY\BunnyNet\Model\Api\Base\Purge\PurgeUrlByHeader;
+use ToshY\BunnyNet\Model\Api\Base\Search\GlobalSearch;
+use ToshY\BunnyNet\Model\Api\Base\StorageZone\GetStorageZoneConnections;
+use ToshY\BunnyNet\Model\Api\Base\Support\CloseTicket;
+use ToshY\BunnyNet\Model\Api\Base\Support\CreateTicket;
+use ToshY\BunnyNet\Model\Api\Base\Support\GetTicketDetails;
+use ToshY\BunnyNet\Model\Api\Base\Support\ListTickets;
+use ToshY\BunnyNet\Model\Api\Base\Support\ReplyTicket;
+use ToshY\BunnyNet\Model\Api\Base\User\AcceptDpa;
+use ToshY\BunnyNet\Model\Api\Base\User\CloseAccount;
+use ToshY\BunnyNet\Model\Api\Base\User\DisableTwoFactorAuthentication;
+use ToshY\BunnyNet\Model\Api\Base\User\EnableTwoFactorAuthentication;
+use ToshY\BunnyNet\Model\Api\Base\User\GenerateTwoFactorAuthenticationVerification;
+use ToshY\BunnyNet\Model\Api\Base\User\GetDpaDetails;
+use ToshY\BunnyNet\Model\Api\Base\User\GetDpaDetailsHtml;
+use ToshY\BunnyNet\Model\Api\Base\User\GetHomeFeed;
+use ToshY\BunnyNet\Model\Api\Base\User\GetUserDetails;
+use ToshY\BunnyNet\Model\Api\Base\User\GetWhatsNewItems;
+use ToshY\BunnyNet\Model\Api\Base\User\ListCloseAccountReasons;
+use ToshY\BunnyNet\Model\Api\Base\User\ListNotifications;
+use ToshY\BunnyNet\Model\Api\Base\User\ResendEmailConfirmation;
+use ToshY\BunnyNet\Model\Api\Base\User\ResetApiKey;
+use ToshY\BunnyNet\Model\Api\Base\User\ResetWhatsNew;
+use ToshY\BunnyNet\Model\Api\Base\User\SetNotificationsOpened;
+use ToshY\BunnyNet\Model\Api\Base\User\UpdateUserDetails;
+use ToshY\BunnyNet\Model\Api\Base\User\VerifyTwoFactorAuthenticationCode;
 
 require_once __DIR__ . '/../../vendor/autoload.php';
 
@@ -54,12 +102,162 @@ foreach ($manifests as $file) {
         default => [],
     };
 
+    // Endpoints that are still available to use but no longer in the OpenAPI specs
+    $keepUndocumentedEndpoints = match ($key) {
+        \ToshY\BunnyNet\Enum\Generator::BASE->value => [
+            '/abusecase' => [
+                'get' => ListAbuseCases::class,
+            ],
+            '/dmca/{id}' => [
+                'get' => GetDmcaCase::class,
+            ],
+            '/abusecase/{id}' => [
+                'get' => GetAbuseCase::class,
+            ],
+            '/dmca/{id}/resolve' => [
+                'post' => ResolveDmcaCase::class,
+            ],
+            '/abusecase/{id}/resolve' => [
+                'post' => ResolveAbuseCase::class,
+            ],
+            '/abusecase/{id}/check' => [
+                'post' => CheckAbuseCase::class,
+            ],
+            '/auth/jwt/2fa' => [
+                'post' => AuthJwt2fa::class,
+            ],
+            '/auth/jwt/refresh' => [
+                'post' => RefreshJwt::class,
+            ],
+            '/billing' => [
+                'get' => GetBillingDetails::class,
+            ],
+            '/billing/payment/autorecharge' => [
+                'post' => ConfigureAutoRecharge::class,
+            ],
+            '/billing/payment/checkout' => [
+                'post' => CreatePaymentCheckout::class,
+            ],
+            '/billing/payment/prepare-authorization' => [
+                'get' => PreparePaymentAuthorization::class,
+            ],
+            '/billing/affiliate' => [
+                'get' => GetAffiliateDetails::class,
+            ],
+            '/billing/affiliate/claim' => [
+                'post' => ClaimAffiliateCredits::class,
+            ],
+            '/billing/coinify/exchangerate' => [
+                'get' => GetCoinifyBitcoinExchangeRate::class,
+            ],
+            '/billing/coinify/create' => [
+                'get' => CreateCoinifyPayment::class,
+            ],
+            '/billing/summary' => [
+                'get' => GetBillingSummary::class,
+            ],
+            '/billing/summary/{billingRecordId}/pdf' => [
+                'get' => GetBillingSummaryPDF::class,
+            ],
+            '/billing/applycode' => [
+                'get' => ApplyPromoCode::class,
+            ],
+            '/dnszone/{id}/recheckdns' => [
+                'post' => RecheckDnsConfiguration::class,
+            ],
+            '/dnszone/{id}/dismissnameservercheck' => [
+                'post' => DismissDnsConfigurationNotice::class,
+            ],
+            '/drmcertificate' => [
+                'get' => ListDrmCertificates::class,
+            ],
+            '/purge' => [
+                'get' => PurgeUrlByHeader::class,
+            ],
+            '/search' => [
+                'get' => GlobalSearch::class,
+            ],
+            '/support/ticket/list' => [
+                'get' => ListTickets::class,
+            ],
+            '/support/ticket/details/{id}' => [
+                'get' => GetTicketDetails::class,
+            ],
+            '/support/ticket/{id}/close' => [
+                'post' => CloseTicket::class,
+            ],
+            '/support/ticket/{id}/reply' => [
+                'post' => ReplyTicket::class,
+            ],
+            '/support/ticket/create' => [
+                'post' => CreateTicket::class,
+            ],
+            '/storagezone/{id}/connections' => [
+                'get' => GetStorageZoneConnections::class,
+            ],
+            '/user/homefeed' => [
+                'get' => GetHomeFeed::class,
+            ],
+            '/user/notifications' => [
+                'get' => ListNotifications::class,
+            ],
+            '/user' => [
+                'get' => GetUserDetails::class,
+                'post' => UpdateUserDetails::class,
+            ],
+            '/user/resend-email-confirmation' => [
+                'post' => ResendEmailConfirmation::class,
+            ],
+            '/user/resetApiKey' => [
+                'post' => ResetApiKey::class,
+            ],
+            '/user/closeaccount/reasons-list' => [
+                'get' => ListCloseAccountReasons::class,
+            ],
+            '/user/closeaccount' => [
+                'post' => CloseAccount::class,
+            ],
+            '/user/dpa' => [
+                'get' => GetDpaDetails::class,
+            ],
+            '/user/dpa/accept' => [
+                'post' => AcceptDpa::class,
+            ],
+            '/user/dpa/pdfhtml' => [
+                'get' => GetDpaDetailsHtml::class,
+            ],
+            '/user/setNotificationsOpened' => [
+                'post' => SetNotificationsOpened::class,
+            ],
+            '/user/whatsnew' => [
+                'get' => GetWhatsNewItems::class,
+            ],
+            '/user/whatsnew/reset' => [
+                'post' => ResetWhatsNew::class,
+            ],
+            '/user/2fa/generate-verification' => [
+                'get' => GenerateTwoFactorAuthenticationVerification::class,
+            ],
+            '/user/2fa/disable' => [
+                'post' => DisableTwoFactorAuthentication::class,
+            ],
+            '/user/2fa/enable' => [
+                'post' => EnableTwoFactorAuthentication::class,
+            ],
+            '/user/2fa/verify' => [
+                'post' => VerifyTwoFactorAuthenticationCode::class,
+            ],
+        ],
+        default => [],
+    };
+
     $data[$key] = [
         'apiSpecPath' => $file['fileUrl'],
         'modelDirectory' => $modelInputDirectory . '/' . $key,
         'mappingClassName' => $key,
         'outputDirectory' => $outputDirectory,
         'ignoreEndpoints' => $ignoreEndpoints,
+        'keepUndocumentedEndpoints' => $keepUndocumentedEndpoints,
     ];
 }
 
@@ -70,6 +268,7 @@ foreach ($data as $namespace => $config) {
         $config['mappingClassName'],
         $config['modelDirectory'],
         $config['ignoreEndpoints'],
+        $config['keepUndocumentedEndpoints'],
     );
     $generator->generate();
 

--- a/generator/Command/generate-maps.php
+++ b/generator/Command/generate-maps.php
@@ -2,56 +2,9 @@
 
 declare(strict_types=1);
 
+use ToshY\BunnyNet\Generator\Enum\EndpointEdgeCases;
 use ToshY\BunnyNet\Generator\Generator\MapGenerator;
 use ToshY\BunnyNet\Generator\Utils\FileUtils;
-use ToshY\BunnyNet\Model\Api\Base\AbuseCase\CheckAbuseCase;
-use ToshY\BunnyNet\Model\Api\Base\AbuseCase\GetAbuseCase;
-use ToshY\BunnyNet\Model\Api\Base\AbuseCase\GetDmcaCase;
-use ToshY\BunnyNet\Model\Api\Base\AbuseCase\ListAbuseCases;
-use ToshY\BunnyNet\Model\Api\Base\AbuseCase\ResolveAbuseCase;
-use ToshY\BunnyNet\Model\Api\Base\AbuseCase\ResolveDmcaCase;
-use ToshY\BunnyNet\Model\Api\Base\Auth\AuthJwt2fa;
-use ToshY\BunnyNet\Model\Api\Base\Auth\RefreshJwt;
-use ToshY\BunnyNet\Model\Api\Base\Billing\ApplyPromoCode;
-use ToshY\BunnyNet\Model\Api\Base\Billing\ClaimAffiliateCredits;
-use ToshY\BunnyNet\Model\Api\Base\Billing\ConfigureAutoRecharge;
-use ToshY\BunnyNet\Model\Api\Base\Billing\CreateCoinifyPayment;
-use ToshY\BunnyNet\Model\Api\Base\Billing\CreatePaymentCheckout;
-use ToshY\BunnyNet\Model\Api\Base\Billing\GetAffiliateDetails;
-use ToshY\BunnyNet\Model\Api\Base\Billing\GetBillingDetails;
-use ToshY\BunnyNet\Model\Api\Base\Billing\GetBillingSummary;
-use ToshY\BunnyNet\Model\Api\Base\Billing\GetBillingSummaryPDF;
-use ToshY\BunnyNet\Model\Api\Base\Billing\GetCoinifyBitcoinExchangeRate;
-use ToshY\BunnyNet\Model\Api\Base\Billing\PreparePaymentAuthorization;
-use ToshY\BunnyNet\Model\Api\Base\DnsZone\DismissDnsConfigurationNotice;
-use ToshY\BunnyNet\Model\Api\Base\DnsZone\RecheckDnsConfiguration;
-use ToshY\BunnyNet\Model\Api\Base\DrmCertificate\ListDrmCertificates;
-use ToshY\BunnyNet\Model\Api\Base\Purge\PurgeUrlByHeader;
-use ToshY\BunnyNet\Model\Api\Base\Search\GlobalSearch;
-use ToshY\BunnyNet\Model\Api\Base\StorageZone\GetStorageZoneConnections;
-use ToshY\BunnyNet\Model\Api\Base\Support\CloseTicket;
-use ToshY\BunnyNet\Model\Api\Base\Support\CreateTicket;
-use ToshY\BunnyNet\Model\Api\Base\Support\GetTicketDetails;
-use ToshY\BunnyNet\Model\Api\Base\Support\ListTickets;
-use ToshY\BunnyNet\Model\Api\Base\Support\ReplyTicket;
-use ToshY\BunnyNet\Model\Api\Base\User\AcceptDpa;
-use ToshY\BunnyNet\Model\Api\Base\User\CloseAccount;
-use ToshY\BunnyNet\Model\Api\Base\User\DisableTwoFactorAuthentication;
-use ToshY\BunnyNet\Model\Api\Base\User\EnableTwoFactorAuthentication;
-use ToshY\BunnyNet\Model\Api\Base\User\GenerateTwoFactorAuthenticationVerification;
-use ToshY\BunnyNet\Model\Api\Base\User\GetDpaDetails;
-use ToshY\BunnyNet\Model\Api\Base\User\GetDpaDetailsHtml;
-use ToshY\BunnyNet\Model\Api\Base\User\GetHomeFeed;
-use ToshY\BunnyNet\Model\Api\Base\User\GetUserDetails;
-use ToshY\BunnyNet\Model\Api\Base\User\GetWhatsNewItems;
-use ToshY\BunnyNet\Model\Api\Base\User\ListCloseAccountReasons;
-use ToshY\BunnyNet\Model\Api\Base\User\ListNotifications;
-use ToshY\BunnyNet\Model\Api\Base\User\ResendEmailConfirmation;
-use ToshY\BunnyNet\Model\Api\Base\User\ResetApiKey;
-use ToshY\BunnyNet\Model\Api\Base\User\ResetWhatsNew;
-use ToshY\BunnyNet\Model\Api\Base\User\SetNotificationsOpened;
-use ToshY\BunnyNet\Model\Api\Base\User\UpdateUserDetails;
-use ToshY\BunnyNet\Model\Api\Base\User\VerifyTwoFactorAuthenticationCode;
 
 require_once __DIR__ . '/../../vendor/autoload.php';
 
@@ -87,167 +40,9 @@ foreach ($manifests as $file) {
         ),
     };
 
-    $ignoreEndpoints = match ($key) {
-        \ToshY\BunnyNet\Enum\Generator::BASE->value => [
-            /* Changed to EdgeScripting */
-            '/compute/script',
-            '/compute/script/{id}',
-            '/compute/script/{id}/code',
-            '/compute/script/{id}/releases',
-            '/compute/script/{id}/publish',
-            '/compute/script/{id}/publish/{uuid}',
-            '/compute/script/{id}/variables/add',
-            '/compute/script/{id}/variables/{variableId}',
-        ],
-        default => [],
-    };
-
     // Endpoints that are still available to use but no longer in the OpenAPI specs
     $keepUndocumentedEndpoints = match ($key) {
-        \ToshY\BunnyNet\Enum\Generator::BASE->value => [
-            '/abusecase' => [
-                'get' => ListAbuseCases::class,
-            ],
-            '/dmca/{id}' => [
-                'get' => GetDmcaCase::class,
-            ],
-            '/abusecase/{id}' => [
-                'get' => GetAbuseCase::class,
-            ],
-            '/dmca/{id}/resolve' => [
-                'post' => ResolveDmcaCase::class,
-            ],
-            '/abusecase/{id}/resolve' => [
-                'post' => ResolveAbuseCase::class,
-            ],
-            '/abusecase/{id}/check' => [
-                'post' => CheckAbuseCase::class,
-            ],
-            '/auth/jwt/2fa' => [
-                'post' => AuthJwt2fa::class,
-            ],
-            '/auth/jwt/refresh' => [
-                'post' => RefreshJwt::class,
-            ],
-            '/billing' => [
-                'get' => GetBillingDetails::class,
-            ],
-            '/billing/payment/autorecharge' => [
-                'post' => ConfigureAutoRecharge::class,
-            ],
-            '/billing/payment/checkout' => [
-                'post' => CreatePaymentCheckout::class,
-            ],
-            '/billing/payment/prepare-authorization' => [
-                'get' => PreparePaymentAuthorization::class,
-            ],
-            '/billing/affiliate' => [
-                'get' => GetAffiliateDetails::class,
-            ],
-            '/billing/affiliate/claim' => [
-                'post' => ClaimAffiliateCredits::class,
-            ],
-            '/billing/coinify/exchangerate' => [
-                'get' => GetCoinifyBitcoinExchangeRate::class,
-            ],
-            '/billing/coinify/create' => [
-                'get' => CreateCoinifyPayment::class,
-            ],
-            '/billing/summary' => [
-                'get' => GetBillingSummary::class,
-            ],
-            '/billing/summary/{billingRecordId}/pdf' => [
-                'get' => GetBillingSummaryPDF::class,
-            ],
-            '/billing/applycode' => [
-                'get' => ApplyPromoCode::class,
-            ],
-            '/dnszone/{id}/recheckdns' => [
-                'post' => RecheckDnsConfiguration::class,
-            ],
-            '/dnszone/{id}/dismissnameservercheck' => [
-                'post' => DismissDnsConfigurationNotice::class,
-            ],
-            '/drmcertificate' => [
-                'get' => ListDrmCertificates::class,
-            ],
-            '/purge' => [
-                'get' => PurgeUrlByHeader::class,
-            ],
-            '/search' => [
-                'get' => GlobalSearch::class,
-            ],
-            '/support/ticket/list' => [
-                'get' => ListTickets::class,
-            ],
-            '/support/ticket/details/{id}' => [
-                'get' => GetTicketDetails::class,
-            ],
-            '/support/ticket/{id}/close' => [
-                'post' => CloseTicket::class,
-            ],
-            '/support/ticket/{id}/reply' => [
-                'post' => ReplyTicket::class,
-            ],
-            '/support/ticket/create' => [
-                'post' => CreateTicket::class,
-            ],
-            '/storagezone/{id}/connections' => [
-                'get' => GetStorageZoneConnections::class,
-            ],
-            '/user/homefeed' => [
-                'get' => GetHomeFeed::class,
-            ],
-            '/user/notifications' => [
-                'get' => ListNotifications::class,
-            ],
-            '/user' => [
-                'get' => GetUserDetails::class,
-                'post' => UpdateUserDetails::class,
-            ],
-            '/user/resend-email-confirmation' => [
-                'post' => ResendEmailConfirmation::class,
-            ],
-            '/user/resetApiKey' => [
-                'post' => ResetApiKey::class,
-            ],
-            '/user/closeaccount/reasons-list' => [
-                'get' => ListCloseAccountReasons::class,
-            ],
-            '/user/closeaccount' => [
-                'post' => CloseAccount::class,
-            ],
-            '/user/dpa' => [
-                'get' => GetDpaDetails::class,
-            ],
-            '/user/dpa/accept' => [
-                'post' => AcceptDpa::class,
-            ],
-            '/user/dpa/pdfhtml' => [
-                'get' => GetDpaDetailsHtml::class,
-            ],
-            '/user/setNotificationsOpened' => [
-                'post' => SetNotificationsOpened::class,
-            ],
-            '/user/whatsnew' => [
-                'get' => GetWhatsNewItems::class,
-            ],
-            '/user/whatsnew/reset' => [
-                'post' => ResetWhatsNew::class,
-            ],
-            '/user/2fa/generate-verification' => [
-                'get' => GenerateTwoFactorAuthenticationVerification::class,
-            ],
-            '/user/2fa/disable' => [
-                'post' => DisableTwoFactorAuthentication::class,
-            ],
-            '/user/2fa/enable' => [
-                'post' => EnableTwoFactorAuthentication::class,
-            ],
-            '/user/2fa/verify' => [
-                'post' => VerifyTwoFactorAuthenticationCode::class,
-            ],
-        ],
+        \ToshY\BunnyNet\Enum\Generator::BASE->value => EndpointEdgeCases::BASE_API_UNDOCUMENTED_IN_OPEN_API_SPECS,
         default => [],
     };
 
@@ -256,7 +51,7 @@ foreach ($manifests as $file) {
         'modelDirectory' => $modelInputDirectory . '/' . $key,
         'mappingClassName' => $key,
         'outputDirectory' => $outputDirectory,
-        'ignoreEndpoints' => $ignoreEndpoints,
+        'ignoreEndpoints' => [],
         'keepUndocumentedEndpoints' => $keepUndocumentedEndpoints,
     ];
 }

--- a/generator/Command/generate-models.php
+++ b/generator/Command/generate-models.php
@@ -3,13 +3,12 @@
 declare(strict_types=1);
 
 use ToshY\BunnyNet\Enum\Header;
-use ToshY\BunnyNet\Enum\Validation\ModelValidationStrategy;
+use ToshY\BunnyNet\Generator\Enum\EndpointEdgeCases;
 use ToshY\BunnyNet\Generator\Generator\ModelGenerator;
 use ToshY\BunnyNet\Generator\Utils\ClassUtils;
 use ToshY\BunnyNet\Generator\Utils\FileUtils;
 use ToshY\BunnyNet\Generator\Utils\LoggerUtils;
 use ToshY\BunnyNet\Model\Api\Base\DnsZone\ImportDnsRecords;
-use ToshY\BunnyNet\Model\Api\Base\Integration\GetGitHubIntegration;
 use ToshY\BunnyNet\Model\Api\EdgeStorage\ManageFiles\DownloadZip;
 use ToshY\BunnyNet\Model\Api\EdgeStorage\ManageFiles\UploadFile;
 use ToshY\BunnyNet\Model\Api\Stream\ManageVideos\UploadVideo;
@@ -100,12 +99,8 @@ foreach ($manifests as $file) {
     };
 
     $validationReplacements  = match ($key) {
-        \ToshY\BunnyNet\Enum\Generator::BASE->value, => [
-            GetGitHubIntegration::class => ModelValidationStrategy::NONE,
-        ],
-        \ToshY\BunnyNet\Enum\Generator::EDGE_STORAGE->value, => [
-            DownloadZip::class => ModelValidationStrategy::STRICT_BODY,
-        ],
+        \ToshY\BunnyNet\Enum\Generator::BASE->value, => EndpointEdgeCases::BASE_API_VALIDATION_REPLACEMENTS,
+        \ToshY\BunnyNet\Enum\Generator::EDGE_STORAGE->value, => EndpointEdgeCases::EDGE_STORAGE_VALIDATION_REPLACEMENTS,
         default => [],
     };
 

--- a/generator/Enum/EndpointEdgeCases.php
+++ b/generator/Enum/EndpointEdgeCases.php
@@ -1,0 +1,261 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ToshY\BunnyNet\Generator\Enum;
+
+use ToshY\BunnyNet\Enum\Validation\ModelValidationStrategy;
+use ToshY\BunnyNet\Model\Api\Base\AbuseCase\CheckAbuseCase;
+use ToshY\BunnyNet\Model\Api\Base\AbuseCase\GetAbuseCase;
+use ToshY\BunnyNet\Model\Api\Base\AbuseCase\GetDmcaCase;
+use ToshY\BunnyNet\Model\Api\Base\AbuseCase\ListAbuseCases;
+use ToshY\BunnyNet\Model\Api\Base\AbuseCase\ResolveAbuseCase;
+use ToshY\BunnyNet\Model\Api\Base\AbuseCase\ResolveDmcaCase;
+use ToshY\BunnyNet\Model\Api\Base\Auth\AuthJwt2fa;
+use ToshY\BunnyNet\Model\Api\Base\Auth\RefreshJwt;
+use ToshY\BunnyNet\Model\Api\Base\Billing\ApplyPromoCode;
+use ToshY\BunnyNet\Model\Api\Base\Billing\ClaimAffiliateCredits;
+use ToshY\BunnyNet\Model\Api\Base\Billing\ConfigureAutoRecharge;
+use ToshY\BunnyNet\Model\Api\Base\Billing\CreateCoinifyPayment;
+use ToshY\BunnyNet\Model\Api\Base\Billing\CreatePaymentCheckout;
+use ToshY\BunnyNet\Model\Api\Base\Billing\GetAffiliateDetails;
+use ToshY\BunnyNet\Model\Api\Base\Billing\GetBillingDetails;
+use ToshY\BunnyNet\Model\Api\Base\Billing\GetBillingSummary;
+use ToshY\BunnyNet\Model\Api\Base\Billing\GetBillingSummaryPDF;
+use ToshY\BunnyNet\Model\Api\Base\Billing\GetCoinifyBitcoinExchangeRate;
+use ToshY\BunnyNet\Model\Api\Base\Billing\PreparePaymentAuthorization;
+use ToshY\BunnyNet\Model\Api\Base\DnsZone\DismissDnsConfigurationNotice;
+use ToshY\BunnyNet\Model\Api\Base\DnsZone\RecheckDnsConfiguration;
+use ToshY\BunnyNet\Model\Api\Base\DrmCertificate\ListDrmCertificates;
+use ToshY\BunnyNet\Model\Api\Base\Integration\GetGitHubIntegration;
+use ToshY\BunnyNet\Model\Api\Base\Purge\PurgeUrlByHeader;
+use ToshY\BunnyNet\Model\Api\Base\Search\GlobalSearch;
+use ToshY\BunnyNet\Model\Api\Base\StorageZone\GetStorageZoneConnections;
+use ToshY\BunnyNet\Model\Api\Base\Support\CloseTicket;
+use ToshY\BunnyNet\Model\Api\Base\Support\CreateTicket;
+use ToshY\BunnyNet\Model\Api\Base\Support\GetTicketDetails;
+use ToshY\BunnyNet\Model\Api\Base\Support\ListTickets;
+use ToshY\BunnyNet\Model\Api\Base\Support\ReplyTicket;
+use ToshY\BunnyNet\Model\Api\Base\User\AcceptDpa;
+use ToshY\BunnyNet\Model\Api\Base\User\CloseAccount;
+use ToshY\BunnyNet\Model\Api\Base\User\DisableTwoFactorAuthentication;
+use ToshY\BunnyNet\Model\Api\Base\User\EnableTwoFactorAuthentication;
+use ToshY\BunnyNet\Model\Api\Base\User\GenerateTwoFactorAuthenticationVerification;
+use ToshY\BunnyNet\Model\Api\Base\User\GetDpaDetails;
+use ToshY\BunnyNet\Model\Api\Base\User\GetDpaDetailsHtml;
+use ToshY\BunnyNet\Model\Api\Base\User\GetHomeFeed;
+use ToshY\BunnyNet\Model\Api\Base\User\GetUserDetails;
+use ToshY\BunnyNet\Model\Api\Base\User\GetWhatsNewItems;
+use ToshY\BunnyNet\Model\Api\Base\User\ListCloseAccountReasons;
+use ToshY\BunnyNet\Model\Api\Base\User\ListNotifications;
+use ToshY\BunnyNet\Model\Api\Base\User\ResendEmailConfirmation;
+use ToshY\BunnyNet\Model\Api\Base\User\ResetApiKey;
+use ToshY\BunnyNet\Model\Api\Base\User\ResetWhatsNew;
+use ToshY\BunnyNet\Model\Api\Base\User\SetNotificationsOpened;
+use ToshY\BunnyNet\Model\Api\Base\User\UpdateUserDetails;
+use ToshY\BunnyNet\Model\Api\Base\User\VerifyTwoFactorAuthenticationCode;
+use ToshY\BunnyNet\Model\Api\EdgeStorage\ManageFiles\DownloadZip;
+
+final class EndpointEdgeCases
+{
+    public const BASE_API_UNDOCUMENTED_IN_OPEN_API_SPECS = [
+        '/abusecase' => [
+            'get' => ListAbuseCases::class,
+        ],
+        '/dmca/{id}' => [
+            'get' => GetDmcaCase::class,
+        ],
+        '/abusecase/{id}' => [
+            'get' => GetAbuseCase::class,
+        ],
+        '/dmca/{id}/resolve' => [
+            'post' => ResolveDmcaCase::class,
+        ],
+        '/abusecase/{id}/resolve' => [
+            'post' => ResolveAbuseCase::class,
+        ],
+        '/abusecase/{id}/check' => [
+            'post' => CheckAbuseCase::class,
+        ],
+        '/auth/jwt/2fa' => [
+            'post' => AuthJwt2fa::class,
+        ],
+        '/auth/jwt/refresh' => [
+            'post' => RefreshJwt::class,
+        ],
+        '/billing' => [
+            'get' => GetBillingDetails::class,
+        ],
+        '/billing/payment/autorecharge' => [
+            'post' => ConfigureAutoRecharge::class,
+        ],
+        '/billing/payment/checkout' => [
+            'post' => CreatePaymentCheckout::class,
+        ],
+        '/billing/payment/prepare-authorization' => [
+            'get' => PreparePaymentAuthorization::class,
+        ],
+        '/billing/affiliate' => [
+            'get' => GetAffiliateDetails::class,
+        ],
+        '/billing/affiliate/claim' => [
+            'post' => ClaimAffiliateCredits::class,
+        ],
+        '/billing/coinify/exchangerate' => [
+            'get' => GetCoinifyBitcoinExchangeRate::class,
+        ],
+        '/billing/coinify/create' => [
+            'get' => CreateCoinifyPayment::class,
+        ],
+        '/billing/summary' => [
+            'get' => GetBillingSummary::class,
+        ],
+        '/billing/summary/{billingRecordId}/pdf' => [
+            'get' => GetBillingSummaryPDF::class,
+        ],
+        '/billing/applycode' => [
+            'get' => ApplyPromoCode::class,
+        ],
+        '/dnszone/{id}/recheckdns' => [
+            'post' => RecheckDnsConfiguration::class,
+        ],
+        '/dnszone/{id}/dismissnameservercheck' => [
+            'post' => DismissDnsConfigurationNotice::class,
+        ],
+        '/drmcertificate' => [
+            'get' => ListDrmCertificates::class,
+        ],
+        '/purge' => [
+            'get' => PurgeUrlByHeader::class,
+        ],
+        '/search' => [
+            'get' => GlobalSearch::class,
+        ],
+        '/support/ticket/list' => [
+            'get' => ListTickets::class,
+        ],
+        '/support/ticket/details/{id}' => [
+            'get' => GetTicketDetails::class,
+        ],
+        '/support/ticket/{id}/close' => [
+            'post' => CloseTicket::class,
+        ],
+        '/support/ticket/{id}/reply' => [
+            'post' => ReplyTicket::class,
+        ],
+        '/support/ticket/create' => [
+            'post' => CreateTicket::class,
+        ],
+        '/storagezone/{id}/connections' => [
+            'get' => GetStorageZoneConnections::class,
+        ],
+        '/user/homefeed' => [
+            'get' => GetHomeFeed::class,
+        ],
+        '/user/notifications' => [
+            'get' => ListNotifications::class,
+        ],
+        '/user' => [
+            'get' => GetUserDetails::class,
+            'post' => UpdateUserDetails::class,
+        ],
+        '/user/resend-email-confirmation' => [
+            'post' => ResendEmailConfirmation::class,
+        ],
+        '/user/resetApiKey' => [
+            'post' => ResetApiKey::class,
+        ],
+        '/user/closeaccount/reasons-list' => [
+            'get' => ListCloseAccountReasons::class,
+        ],
+        '/user/closeaccount' => [
+            'post' => CloseAccount::class,
+        ],
+        '/user/dpa' => [
+            'get' => GetDpaDetails::class,
+        ],
+        '/user/dpa/accept' => [
+            'post' => AcceptDpa::class,
+        ],
+        '/user/dpa/pdfhtml' => [
+            'get' => GetDpaDetailsHtml::class,
+        ],
+        '/user/setNotificationsOpened' => [
+            'post' => SetNotificationsOpened::class,
+        ],
+        '/user/whatsnew' => [
+            'get' => GetWhatsNewItems::class,
+        ],
+        '/user/whatsnew/reset' => [
+            'post' => ResetWhatsNew::class,
+        ],
+        '/user/2fa/generate-verification' => [
+            'get' => GenerateTwoFactorAuthenticationVerification::class,
+        ],
+        '/user/2fa/disable' => [
+            'post' => DisableTwoFactorAuthentication::class,
+        ],
+        '/user/2fa/enable' => [
+            'post' => EnableTwoFactorAuthentication::class,
+        ],
+        '/user/2fa/verify' => [
+            'post' => VerifyTwoFactorAuthenticationCode::class,
+        ],
+    ];
+
+    public const BASE_API_VALIDATION_REPLACEMENTS = [
+        ListAbuseCases::class => ModelValidationStrategy::STRICT_QUERY,
+        GetDmcaCase::class => ModelValidationStrategy::NONE,
+        GetAbuseCase::class => ModelValidationStrategy::NONE,
+        ResolveDmcaCase::class => ModelValidationStrategy::NONE,
+        ResolveAbuseCase::class => ModelValidationStrategy::NONE,
+        CheckAbuseCase::class => ModelValidationStrategy::NONE,
+        AuthJwt2fa::class => ModelValidationStrategy::STRICT_BODY,
+        RefreshJwt::class => ModelValidationStrategy::NONE,
+        GetBillingDetails::class => ModelValidationStrategy::NONE,
+        ConfigureAutoRecharge::class => ModelValidationStrategy::STRICT_BODY,
+        CreatePaymentCheckout::class => ModelValidationStrategy::STRICT_BODY,
+        PreparePaymentAuthorization::class => ModelValidationStrategy::NONE,
+        GetAffiliateDetails::class => ModelValidationStrategy::NONE,
+        ClaimAffiliateCredits::class => ModelValidationStrategy::NONE,
+        GetCoinifyBitcoinExchangeRate::class => ModelValidationStrategy::NONE,
+        CreateCoinifyPayment::class => ModelValidationStrategy::STRICT_QUERY,
+        GetBillingSummary::class => ModelValidationStrategy::NONE,
+        GetBillingSummaryPDF::class => ModelValidationStrategy::NONE,
+        ApplyPromoCode::class => ModelValidationStrategy::STRICT_QUERY,
+        RecheckDnsConfiguration::class => ModelValidationStrategy::NONE,
+        DismissDnsConfigurationNotice::class => ModelValidationStrategy::NONE,
+        ListDrmCertificates::class => ModelValidationStrategy::STRICT_QUERY,
+        PurgeUrlByHeader::class => ModelValidationStrategy::STRICT_QUERY,
+        ListTickets::class => ModelValidationStrategy::STRICT_QUERY,
+        GetTicketDetails::class => ModelValidationStrategy::NONE,
+        CloseTicket::class => ModelValidationStrategy::NONE,
+        ReplyTicket::class => ModelValidationStrategy::STRICT_BODY,
+        CreateTicket::class => ModelValidationStrategy::STRICT_BODY,
+        GetStorageZoneConnections::class => ModelValidationStrategy::NONE,
+        GetHomeFeed::class => ModelValidationStrategy::NONE,
+        ListNotifications::class => ModelValidationStrategy::NONE,
+        GetUserDetails::class => ModelValidationStrategy::NONE,
+        UpdateUserDetails::class => ModelValidationStrategy::STRICT_BODY,
+        ResendEmailConfirmation::class => ModelValidationStrategy::NONE,
+        ResetApiKey::class => ModelValidationStrategy::NONE,
+        ListCloseAccountReasons::class => ModelValidationStrategy::NONE,
+        CloseAccount::class => ModelValidationStrategy::STRICT_BODY,
+        GetDpaDetails::class => ModelValidationStrategy::NONE,
+        AcceptDpa::class => ModelValidationStrategy::NONE,
+        GetDpaDetailsHtml::class => ModelValidationStrategy::NONE,
+        SetNotificationsOpened::class => ModelValidationStrategy::NONE,
+        GetWhatsNewItems::class => ModelValidationStrategy::NONE,
+        ResetWhatsNew::class => ModelValidationStrategy::NONE,
+        GenerateTwoFactorAuthenticationVerification::class => ModelValidationStrategy::NONE,
+        DisableTwoFactorAuthentication::class => ModelValidationStrategy::STRICT_BODY,
+        EnableTwoFactorAuthentication::class => ModelValidationStrategy::STRICT_BODY,
+        VerifyTwoFactorAuthenticationCode::class => ModelValidationStrategy::STRICT_BODY,
+        GetGitHubIntegration::class => ModelValidationStrategy::NONE,
+        GlobalSearch::class => ModelValidationStrategy::STRICT_QUERY,
+    ];
+
+    public const EDGE_STORAGE_VALIDATION_REPLACEMENTS = [
+        DownloadZip::class => ModelValidationStrategy::STRICT_BODY,
+    ];
+}

--- a/generator/Map/Base.php
+++ b/generator/Map/Base.php
@@ -42,9 +42,9 @@ use ToshY\BunnyNet\Model\Api\Base\DnsZone\RecheckDnsConfiguration;
 use ToshY\BunnyNet\Model\Api\Base\DnsZone\UpdateDnsRecord;
 use ToshY\BunnyNet\Model\Api\Base\DnsZone\UpdateDnsZone;
 use ToshY\BunnyNet\Model\Api\Base\DrmCertificate\ListDrmCertificates;
-use ToshY\BunnyNet\Model\Api\Base\PullZone\AddAllowedReferer as PullZoneAddAllowedReferer;
+use ToshY\BunnyNet\Model\Api\Base\PullZone\AddAllowedReferer;
 use ToshY\BunnyNet\Model\Api\Base\PullZone\AddBlockedIp;
-use ToshY\BunnyNet\Model\Api\Base\PullZone\AddBlockedReferer as PullZoneAddBlockedReferer;
+use ToshY\BunnyNet\Model\Api\Base\PullZone\AddBlockedReferer;
 use ToshY\BunnyNet\Model\Api\Base\PullZone\AddCustomCertificate;
 use ToshY\BunnyNet\Model\Api\Base\PullZone\AddCustomHostname;
 use ToshY\BunnyNet\Model\Api\Base\PullZone\AddOrUpdateEdgeRule;
@@ -59,9 +59,9 @@ use ToshY\BunnyNet\Model\Api\Base\PullZone\GetSafeHopStatistics;
 use ToshY\BunnyNet\Model\Api\Base\PullZone\ListPullZones;
 use ToshY\BunnyNet\Model\Api\Base\PullZone\LoadFreeCertificate;
 use ToshY\BunnyNet\Model\Api\Base\PullZone\PurgeCache;
-use ToshY\BunnyNet\Model\Api\Base\PullZone\RemoveAllowedReferer as PullZoneRemoveAllowedReferer;
+use ToshY\BunnyNet\Model\Api\Base\PullZone\RemoveAllowedReferer;
 use ToshY\BunnyNet\Model\Api\Base\PullZone\RemoveBlockedIp;
-use ToshY\BunnyNet\Model\Api\Base\PullZone\RemoveBlockedReferer as PullZoneRemoveBlockedReferer;
+use ToshY\BunnyNet\Model\Api\Base\PullZone\RemoveBlockedReferer;
 use ToshY\BunnyNet\Model\Api\Base\PullZone\RemoveCertificate;
 use ToshY\BunnyNet\Model\Api\Base\PullZone\RemoveCustomHostname;
 use ToshY\BunnyNet\Model\Api\Base\PullZone\ResetTokenKey;
@@ -83,8 +83,8 @@ use ToshY\BunnyNet\Model\Api\Base\StorageZone\ListStorageZones;
 use ToshY\BunnyNet\Model\Api\Base\StorageZone\ResetPassword as StorageZoneResetPassword;
 use ToshY\BunnyNet\Model\Api\Base\StorageZone\ResetReadOnlyPassword;
 use ToshY\BunnyNet\Model\Api\Base\StorageZone\UpdateStorageZone;
-use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\AddAllowedReferer;
-use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\AddBlockedReferer;
+use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\AddAllowedReferer as StreamVideoLibraryAddAllowedReferer;
+use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\AddBlockedReferer as StreamVideoLibraryAddBlockedReferer;
 use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\AddVideoLibrary;
 use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\AddWatermark;
 use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\DeleteVideoLibrary;
@@ -93,8 +93,8 @@ use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\GetDrmStatistics;
 use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\GetLanguages;
 use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\GetVideoLibrary;
 use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\ListVideoLibraries;
-use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\RemoveAllowedReferer;
-use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\RemoveBlockedReferer;
+use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\RemoveAllowedReferer as StreamVideoLibraryRemoveAllowedReferer;
+use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\RemoveBlockedReferer as StreamVideoLibraryRemoveBlockedReferer;
 use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\ResetPassword;
 use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\ResetPasswordByPathParameter;
 use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\UpdateVideoLibrary;
@@ -129,6 +129,184 @@ final class Base
 {
     /** @var array<string,array<string,class-string|null>> $endpoints */
     public static array $endpoints = [
+        '/pullzone' => [
+            'get' => ListPullZones::class,
+            'post' => AddPullZone::class,
+        ],
+        '/pullzone/{id}' => [
+            'get' => GetPullZone::class,
+            'post' => UpdatePullZone::class,
+            'delete' => DeletePullZone::class,
+        ],
+        '/pullzone/{pullZoneId}/originshield/queuestatistics' => [
+            'get' => GetOriginShieldQueueStatistics::class,
+        ],
+        '/pullzone/{pullZoneId}/safehop/statistics' => [
+            'get' => GetSafeHopStatistics::class,
+        ],
+        '/pullzone/{pullZoneId}/optimizer/statistics' => [
+            'get' => GetOptimizerStatistics::class,
+        ],
+        '/pullzone/loadFreeCertificate' => [
+            'get' => LoadFreeCertificate::class,
+        ],
+        '/pullzone/{pullZoneId}/edgerules/addOrUpdate' => [
+            'post' => AddOrUpdateEdgeRule::class,
+        ],
+        '/pullzone/{pullZoneId}/edgerules/{edgeRuleId}/setEdgeRuleEnabled' => [
+            'post' => SetEdgeRuleEnabled::class,
+        ],
+        '/pullzone/{id}/purgeCache' => [
+            'post' => PurgeCache::class,
+        ],
+        '/pullzone/checkavailability' => [
+            'post' => CheckPullZoneAvailability::class,
+        ],
+        '/pullzone/{id}/addCertificate' => [
+            'post' => AddCustomCertificate::class,
+        ],
+        '/pullzone/{id}/addHostname' => [
+            'post' => AddCustomHostname::class,
+        ],
+        '/pullzone/{id}/setForceSSL' => [
+            'post' => SetForceSsl::class,
+        ],
+        '/pullzone/{id}/resetSecurityKey' => [
+            'post' => ResetTokenKey::class,
+        ],
+        '/pullzone/{id}/addAllowedReferrer' => [
+            'post' => AddAllowedReferer::class,
+        ],
+        '/pullzone/{id}/removeAllowedReferrer' => [
+            'post' => RemoveAllowedReferer::class,
+        ],
+        '/pullzone/{id}/addBlockedReferrer' => [
+            'post' => AddBlockedReferer::class,
+        ],
+        '/pullzone/{id}/removeBlockedReferrer' => [
+            'post' => RemoveBlockedReferer::class,
+        ],
+        '/pullzone/{id}/addBlockedIp' => [
+            'post' => AddBlockedIp::class,
+        ],
+        '/pullzone/{id}/removeBlockedIp' => [
+            'post' => RemoveBlockedIp::class,
+        ],
+        '/pullzone/{pullZoneId}/edgerules/{edgeRuleId}' => [
+            'delete' => DeleteEdgeRule::class,
+        ],
+        '/pullzone/{id}/removeCertificate' => [
+            'delete' => RemoveCertificate::class,
+        ],
+        '/pullzone/{id}/removeHostname' => [
+            'delete' => RemoveCustomHostname::class,
+        ],
+        '/country' => [
+            'get' => ListCountries::class,
+        ],
+        '/dnszone' => [
+            'get' => ListDnsZones::class,
+            'post' => AddDnsZone::class,
+        ],
+        '/dnszone/{id}' => [
+            'get' => GetDnsZone::class,
+            'post' => UpdateDnsZone::class,
+            'delete' => DeleteDnsZone::class,
+        ],
+        '/dnszone/{id}/export' => [
+            'get' => ExportDnsRecords::class,
+        ],
+        '/dnszone/checkavailability' => [
+            'post' => CheckDnsZoneAvailability::class,
+        ],
+        '/dnszone/{zoneId}/records/{id}' => [
+            'post' => UpdateDnsRecord::class,
+            'delete' => DeleteDnsRecord::class,
+        ],
+        '/dnszone/{zoneId}/import' => [
+            'post' => ImportDnsRecords::class,
+        ],
+        '/dnszone/{zoneId}/records' => [
+            'put' => AddDnsRecord::class,
+        ],
+        '/region' => [
+            'get' => ListRegions::class,
+        ],
+        '/videolibrary' => [
+            'get' => ListVideoLibraries::class,
+            'post' => AddVideoLibrary::class,
+        ],
+        '/videolibrary/{id}' => [
+            'get' => GetVideoLibrary::class,
+            'post' => UpdateVideoLibrary::class,
+            'delete' => DeleteVideoLibrary::class,
+        ],
+        '/videolibrary/languages' => [
+            'get' => GetLanguages::class,
+        ],
+        '/videolibrary/resetApiKey' => [
+            'post' => ResetPassword::class,
+        ],
+        '/videolibrary/{id}/resetApiKey' => [
+            'post' => ResetPasswordByPathParameter::class,
+        ],
+        '/videolibrary/{id}/addAllowedReferrer' => [
+            'post' => StreamVideoLibraryAddAllowedReferer::class,
+        ],
+        '/videolibrary/{id}/removeAllowedReferrer' => [
+            'post' => StreamVideoLibraryRemoveAllowedReferer::class,
+        ],
+        '/videolibrary/{id}/addBlockedReferrer' => [
+            'post' => StreamVideoLibraryAddBlockedReferer::class,
+        ],
+        '/videolibrary/{id}/removeBlockedReferrer' => [
+            'post' => StreamVideoLibraryRemoveBlockedReferer::class,
+        ],
+        '/videolibrary/{id}/watermark' => [
+            'put' => AddWatermark::class,
+            'delete' => DeleteWatermark::class,
+        ],
+        '/purge' => [
+            'post' => PurgeUrl::class,
+            'get' => PurgeUrlByHeader::class,
+        ],
+        '/storagezone' => [
+            'get' => ListStorageZones::class,
+            'post' => AddStorageZone::class,
+        ],
+        '/storagezone/{id}' => [
+            'get' => GetStorageZone::class,
+            'post' => UpdateStorageZone::class,
+            'delete' => DeleteStorageZone::class,
+        ],
+        '/storagezone/checkavailability' => [
+            'post' => CheckStorageZoneAvailability::class,
+        ],
+        '/storagezone/{id}/resetPassword' => [
+            'post' => StorageZoneResetPassword::class,
+        ],
+        '/storagezone/resetReadOnlyPassword' => [
+            'post' => ResetReadOnlyPassword::class,
+        ],
+        '/statistics' => [
+            'get' => GetStatistics::class,
+        ],
+        '/storagezone/{id}/statistics' => [
+            'get' => GetStorageZoneStatistics::class,
+        ],
+        '/apikey' => [
+            'get' => ListApiKeys::class,
+        ],
+        '/videolibrary/{id}/drm/statistics' => [
+            'get' => GetDrmStatistics::class,
+        ],
+        '/dnszone/{id}/dnssec' => [
+            'post' => EnableDnssecOnDnsZone::class,
+            'delete' => DisableDnssecOnDnsZone::class,
+        ],
+        '/dnszone/{id}/statistics' => [
+            'get' => GetDnsZoneQueryStatistics::class,
+        ],
         '/abusecase' => [
             'get' => ListAbuseCases::class,
         ],
@@ -152,12 +330,6 @@ final class Base
         ],
         '/auth/jwt/refresh' => [
             'post' => RefreshJwt::class,
-        ],
-        '/search' => [
-            'get' => GlobalSearch::class,
-        ],
-        '/country' => [
-            'get' => ListCountries::class,
         ],
         '/billing' => [
             'get' => GetBillingDetails::class,
@@ -192,8 +364,17 @@ final class Base
         '/billing/applycode' => [
             'get' => ApplyPromoCode::class,
         ],
-        '/apikey' => [
-            'get' => ListApiKeys::class,
+        '/dnszone/{id}/recheckdns' => [
+            'post' => RecheckDnsConfiguration::class,
+        ],
+        '/dnszone/{id}/dismissnameservercheck' => [
+            'post' => DismissDnsConfigurationNotice::class,
+        ],
+        '/drmcertificate' => [
+            'get' => ListDrmCertificates::class,
+        ],
+        '/search' => [
+            'get' => GlobalSearch::class,
         ],
         '/support/ticket/list' => [
             'get' => ListTickets::class,
@@ -210,189 +391,8 @@ final class Base
         '/support/ticket/create' => [
             'post' => CreateTicket::class,
         ],
-        '/drmcertificate' => [
-            'get' => ListDrmCertificates::class,
-        ],
-        '/region' => [
-            'get' => ListRegions::class,
-        ],
-        '/videolibrary' => [
-            'get' => ListVideoLibraries::class,
-            'post' => AddVideoLibrary::class,
-        ],
-        '/videolibrary/{id}' => [
-            'get' => GetVideoLibrary::class,
-            'post' => UpdateVideoLibrary::class,
-            'delete' => DeleteVideoLibrary::class,
-        ],
-        '/videolibrary/languages' => [
-            'get' => GetLanguages::class,
-        ],
-        '/videolibrary/resetApiKey' => [
-            'post' => ResetPassword::class,
-        ],
-        '/videolibrary/{id}/resetApiKey' => [
-            'post' => ResetPasswordByPathParameter::class,
-        ],
-        '/videolibrary/{id}/watermark' => [
-            'put' => AddWatermark::class,
-            'delete' => DeleteWatermark::class,
-        ],
-        '/videolibrary/{id}/addAllowedReferrer' => [
-            'post' => AddAllowedReferer::class,
-        ],
-        '/videolibrary/{id}/removeAllowedReferrer' => [
-            'post' => RemoveAllowedReferer::class,
-        ],
-        '/videolibrary/{id}/addBlockedReferrer' => [
-            'post' => AddBlockedReferer::class,
-        ],
-        '/videolibrary/{id}/removeBlockedReferrer' => [
-            'post' => RemoveBlockedReferer::class,
-        ],
-        '/videolibrary/{id}/drm/statistics' => [
-            'get' => GetDrmStatistics::class,
-        ],
-        '/dnszone' => [
-            'get' => ListDnsZones::class,
-            'post' => AddDnsZone::class,
-        ],
-        '/dnszone/{id}' => [
-            'get' => GetDnsZone::class,
-            'post' => UpdateDnsZone::class,
-            'delete' => DeleteDnsZone::class,
-        ],
-        '/dnszone/{id}/dnssec' => [
-            'post' => EnableDnssecOnDnsZone::class,
-            'delete' => DisableDnssecOnDnsZone::class,
-        ],
-        '/dnszone/{id}/export' => [
-            'get' => ExportDnsRecords::class,
-        ],
-        '/dnszone/{id}/statistics' => [
-            'get' => GetDnsZoneQueryStatistics::class,
-        ],
-        '/dnszone/checkavailability' => [
-            'post' => CheckDnsZoneAvailability::class,
-        ],
-        '/dnszone/{zoneId}/records' => [
-            'put' => AddDnsRecord::class,
-        ],
-        '/dnszone/{zoneId}/records/{id}' => [
-            'post' => UpdateDnsRecord::class,
-            'delete' => DeleteDnsRecord::class,
-        ],
-        '/dnszone/{id}/recheckdns' => [
-            'post' => RecheckDnsConfiguration::class,
-        ],
-        '/dnszone/{id}/dismissnameservercheck' => [
-            'post' => DismissDnsConfigurationNotice::class,
-        ],
-        '/dnszone/{zoneId}/import' => [
-            'post' => ImportDnsRecords::class,
-        ],
-        '/pullzone' => [
-            'get' => ListPullZones::class,
-            'post' => AddPullZone::class,
-        ],
-        '/pullzone/{id}' => [
-            'get' => GetPullZone::class,
-            'post' => UpdatePullZone::class,
-            'delete' => DeletePullZone::class,
-        ],
-        '/pullzone/{pullZoneId}/edgerules/{edgeRuleId}' => [
-            'delete' => DeleteEdgeRule::class,
-        ],
-        '/pullzone/{pullZoneId}/edgerules/addOrUpdate' => [
-            'post' => AddOrUpdateEdgeRule::class,
-        ],
-        '/pullzone/{pullZoneId}/edgerules/{edgeRuleId}/setEdgeRuleEnabled' => [
-            'post' => SetEdgeRuleEnabled::class,
-        ],
-        '/pullzone/{pullZoneId}/originshield/queuestatistics' => [
-            'get' => GetOriginShieldQueueStatistics::class,
-        ],
-        '/pullzone/{pullZoneId}/safehop/statistics' => [
-            'get' => GetSafeHopStatistics::class,
-        ],
-        '/pullzone/{pullZoneId}/optimizer/statistics' => [
-            'get' => GetOptimizerStatistics::class,
-        ],
-        '/pullzone/loadFreeCertificate' => [
-            'get' => LoadFreeCertificate::class,
-        ],
-        '/pullzone/{id}/purgeCache' => [
-            'post' => PurgeCache::class,
-        ],
-        '/pullzone/checkavailability' => [
-            'post' => CheckPullZoneAvailability::class,
-        ],
-        '/pullzone/{id}/addCertificate' => [
-            'post' => AddCustomCertificate::class,
-        ],
-        '/pullzone/{id}/removeCertificate' => [
-            'delete' => RemoveCertificate::class,
-        ],
-        '/pullzone/{id}/addHostname' => [
-            'post' => AddCustomHostname::class,
-        ],
-        '/pullzone/{id}/removeHostname' => [
-            'delete' => RemoveCustomHostname::class,
-        ],
-        '/pullzone/{id}/setForceSSL' => [
-            'post' => SetForceSsl::class,
-        ],
-        '/pullzone/{id}/resetSecurityKey' => [
-            'post' => ResetTokenKey::class,
-        ],
-        '/pullzone/{id}/addAllowedReferrer' => [
-            'post' => PullZoneAddAllowedReferer::class,
-        ],
-        '/pullzone/{id}/removeAllowedReferrer' => [
-            'post' => PullZoneRemoveAllowedReferer::class,
-        ],
-        '/pullzone/{id}/addBlockedReferrer' => [
-            'post' => PullZoneAddBlockedReferer::class,
-        ],
-        '/pullzone/{id}/removeBlockedReferrer' => [
-            'post' => PullZoneRemoveBlockedReferer::class,
-        ],
-        '/pullzone/{id}/addBlockedIp' => [
-            'post' => AddBlockedIp::class,
-        ],
-        '/pullzone/{id}/removeBlockedIp' => [
-            'post' => RemoveBlockedIp::class,
-        ],
-        '/purge' => [
-            'get' => PurgeUrlByHeader::class,
-            'post' => PurgeUrl::class,
-        ],
-        '/statistics' => [
-            'get' => GetStatistics::class,
-        ],
-        '/storagezone' => [
-            'get' => ListStorageZones::class,
-            'post' => AddStorageZone::class,
-        ],
-        '/storagezone/checkavailability' => [
-            'post' => CheckStorageZoneAvailability::class,
-        ],
-        '/storagezone/{id}' => [
-            'get' => GetStorageZone::class,
-            'post' => UpdateStorageZone::class,
-            'delete' => DeleteStorageZone::class,
-        ],
         '/storagezone/{id}/connections' => [
             'get' => GetStorageZoneConnections::class,
-        ],
-        '/storagezone/{id}/statistics' => [
-            'get' => GetStorageZoneStatistics::class,
-        ],
-        '/storagezone/{id}/resetPassword' => [
-            'post' => StorageZoneResetPassword::class,
-        ],
-        '/storagezone/resetReadOnlyPassword' => [
-            'post' => ResetReadOnlyPassword::class,
         ],
         '/user/homefeed' => [
             'get' => GetHomeFeed::class,

--- a/src/Model/Api/Base/AbuseCase/CheckAbuseCase.php
+++ b/src/Model/Api/Base/AbuseCase/CheckAbuseCase.php
@@ -9,6 +9,9 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class CheckAbuseCase implements ModelInterface
 {
     /**

--- a/src/Model/Api/Base/AbuseCase/GetAbuseCase.php
+++ b/src/Model/Api/Base/AbuseCase/GetAbuseCase.php
@@ -9,6 +9,9 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class GetAbuseCase implements ModelInterface
 {
     /**

--- a/src/Model/Api/Base/AbuseCase/GetDmcaCase.php
+++ b/src/Model/Api/Base/AbuseCase/GetDmcaCase.php
@@ -9,6 +9,9 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class GetDmcaCase implements ModelInterface
 {
     /**

--- a/src/Model/Api/Base/AbuseCase/ListAbuseCases.php
+++ b/src/Model/Api/Base/AbuseCase/ListAbuseCases.php
@@ -12,6 +12,9 @@ use ToshY\BunnyNet\Model\AbstractParameter;
 use ToshY\BunnyNet\Model\ModelInterface;
 use ToshY\BunnyNet\Model\QueryModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class ListAbuseCases implements ModelInterface, QueryModelInterface
 {
     /**

--- a/src/Model/Api/Base/AbuseCase/ResolveAbuseCase.php
+++ b/src/Model/Api/Base/AbuseCase/ResolveAbuseCase.php
@@ -8,6 +8,9 @@ use ToshY\BunnyNet\Attributes\PathProperty;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class ResolveAbuseCase implements ModelInterface
 {
     /**

--- a/src/Model/Api/Base/AbuseCase/ResolveDmcaCase.php
+++ b/src/Model/Api/Base/AbuseCase/ResolveDmcaCase.php
@@ -8,6 +8,9 @@ use ToshY\BunnyNet\Attributes\PathProperty;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class ResolveDmcaCase implements ModelInterface
 {
     /**

--- a/src/Model/Api/Base/Auth/AuthJwt2fa.php
+++ b/src/Model/Api/Base/Auth/AuthJwt2fa.php
@@ -12,6 +12,9 @@ use ToshY\BunnyNet\Model\AbstractParameter;
 use ToshY\BunnyNet\Model\BodyModelInterface;
 use ToshY\BunnyNet\Model\ModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class AuthJwt2fa implements ModelInterface, BodyModelInterface
 {
     /**

--- a/src/Model/Api/Base/Auth/RefreshJwt.php
+++ b/src/Model/Api/Base/Auth/RefreshJwt.php
@@ -8,6 +8,9 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class RefreshJwt implements ModelInterface
 {
     public function getMethod(): Method

--- a/src/Model/Api/Base/Billing/ApplyPromoCode.php
+++ b/src/Model/Api/Base/Billing/ApplyPromoCode.php
@@ -12,6 +12,9 @@ use ToshY\BunnyNet\Model\AbstractParameter;
 use ToshY\BunnyNet\Model\ModelInterface;
 use ToshY\BunnyNet\Model\QueryModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class ApplyPromoCode implements ModelInterface, QueryModelInterface
 {
     /**

--- a/src/Model/Api/Base/Billing/ClaimAffiliateCredits.php
+++ b/src/Model/Api/Base/Billing/ClaimAffiliateCredits.php
@@ -8,6 +8,9 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class ClaimAffiliateCredits implements ModelInterface
 {
     public function getMethod(): Method

--- a/src/Model/Api/Base/Billing/ConfigureAutoRecharge.php
+++ b/src/Model/Api/Base/Billing/ConfigureAutoRecharge.php
@@ -12,6 +12,9 @@ use ToshY\BunnyNet\Model\AbstractParameter;
 use ToshY\BunnyNet\Model\BodyModelInterface;
 use ToshY\BunnyNet\Model\ModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class ConfigureAutoRecharge implements ModelInterface, BodyModelInterface
 {
     /**

--- a/src/Model/Api/Base/Billing/CreateCoinifyPayment.php
+++ b/src/Model/Api/Base/Billing/CreateCoinifyPayment.php
@@ -12,6 +12,9 @@ use ToshY\BunnyNet\Model\AbstractParameter;
 use ToshY\BunnyNet\Model\ModelInterface;
 use ToshY\BunnyNet\Model\QueryModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class CreateCoinifyPayment implements ModelInterface, QueryModelInterface
 {
     /**

--- a/src/Model/Api/Base/Billing/CreatePaymentCheckout.php
+++ b/src/Model/Api/Base/Billing/CreatePaymentCheckout.php
@@ -12,6 +12,9 @@ use ToshY\BunnyNet\Model\AbstractParameter;
 use ToshY\BunnyNet\Model\BodyModelInterface;
 use ToshY\BunnyNet\Model\ModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class CreatePaymentCheckout implements ModelInterface, BodyModelInterface
 {
     /**

--- a/src/Model/Api/Base/Billing/GetAffiliateDetails.php
+++ b/src/Model/Api/Base/Billing/GetAffiliateDetails.php
@@ -8,6 +8,9 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class GetAffiliateDetails implements ModelInterface
 {
     public function getMethod(): Method

--- a/src/Model/Api/Base/Billing/GetBillingDetails.php
+++ b/src/Model/Api/Base/Billing/GetBillingDetails.php
@@ -8,6 +8,9 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class GetBillingDetails implements ModelInterface
 {
     public function getMethod(): Method

--- a/src/Model/Api/Base/Billing/GetBillingSummary.php
+++ b/src/Model/Api/Base/Billing/GetBillingSummary.php
@@ -8,6 +8,9 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class GetBillingSummary implements ModelInterface
 {
     public function getMethod(): Method

--- a/src/Model/Api/Base/Billing/GetBillingSummaryPDF.php
+++ b/src/Model/Api/Base/Billing/GetBillingSummaryPDF.php
@@ -9,6 +9,9 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class GetBillingSummaryPDF implements ModelInterface
 {
     /**

--- a/src/Model/Api/Base/Billing/GetCoinifyBitcoinExchangeRate.php
+++ b/src/Model/Api/Base/Billing/GetCoinifyBitcoinExchangeRate.php
@@ -8,6 +8,9 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class GetCoinifyBitcoinExchangeRate implements ModelInterface
 {
     public function getMethod(): Method

--- a/src/Model/Api/Base/Billing/PreparePaymentAuthorization.php
+++ b/src/Model/Api/Base/Billing/PreparePaymentAuthorization.php
@@ -8,6 +8,9 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class PreparePaymentAuthorization implements ModelInterface
 {
     public function getMethod(): Method

--- a/src/Model/Api/Base/DnsZone/DismissDnsConfigurationNotice.php
+++ b/src/Model/Api/Base/DnsZone/DismissDnsConfigurationNotice.php
@@ -9,6 +9,9 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class DismissDnsConfigurationNotice implements ModelInterface
 {
     /**

--- a/src/Model/Api/Base/DnsZone/RecheckDnsConfiguration.php
+++ b/src/Model/Api/Base/DnsZone/RecheckDnsConfiguration.php
@@ -9,6 +9,9 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class RecheckDnsConfiguration implements ModelInterface
 {
     /**

--- a/src/Model/Api/Base/DrmCertificate/ListDrmCertificates.php
+++ b/src/Model/Api/Base/DrmCertificate/ListDrmCertificates.php
@@ -12,6 +12,9 @@ use ToshY\BunnyNet\Model\AbstractParameter;
 use ToshY\BunnyNet\Model\ModelInterface;
 use ToshY\BunnyNet\Model\QueryModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class ListDrmCertificates implements ModelInterface, QueryModelInterface
 {
     /**

--- a/src/Model/Api/Base/Purge/PurgeUrlByHeader.php
+++ b/src/Model/Api/Base/Purge/PurgeUrlByHeader.php
@@ -12,6 +12,9 @@ use ToshY\BunnyNet\Model\AbstractParameter;
 use ToshY\BunnyNet\Model\ModelInterface;
 use ToshY\BunnyNet\Model\QueryModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class PurgeUrlByHeader implements ModelInterface, QueryModelInterface
 {
     /**

--- a/src/Model/Api/Base/Search/GlobalSearch.php
+++ b/src/Model/Api/Base/Search/GlobalSearch.php
@@ -12,6 +12,9 @@ use ToshY\BunnyNet\Model\AbstractParameter;
 use ToshY\BunnyNet\Model\ModelInterface;
 use ToshY\BunnyNet\Model\QueryModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class GlobalSearch implements ModelInterface, QueryModelInterface
 {
     /**

--- a/src/Model/Api/Base/StorageZone/GetStorageZoneConnections.php
+++ b/src/Model/Api/Base/StorageZone/GetStorageZoneConnections.php
@@ -9,6 +9,9 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class GetStorageZoneConnections implements ModelInterface
 {
     /**

--- a/src/Model/Api/Base/Support/CloseTicket.php
+++ b/src/Model/Api/Base/Support/CloseTicket.php
@@ -8,6 +8,9 @@ use ToshY\BunnyNet\Attributes\PathProperty;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class CloseTicket implements ModelInterface
 {
     /**

--- a/src/Model/Api/Base/Support/CreateTicket.php
+++ b/src/Model/Api/Base/Support/CreateTicket.php
@@ -12,6 +12,9 @@ use ToshY\BunnyNet\Model\AbstractParameter;
 use ToshY\BunnyNet\Model\BodyModelInterface;
 use ToshY\BunnyNet\Model\ModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class CreateTicket implements ModelInterface, BodyModelInterface
 {
     /**

--- a/src/Model/Api/Base/Support/GetTicketDetails.php
+++ b/src/Model/Api/Base/Support/GetTicketDetails.php
@@ -9,6 +9,9 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class GetTicketDetails implements ModelInterface
 {
     /**

--- a/src/Model/Api/Base/Support/ListTickets.php
+++ b/src/Model/Api/Base/Support/ListTickets.php
@@ -12,6 +12,9 @@ use ToshY\BunnyNet\Model\AbstractParameter;
 use ToshY\BunnyNet\Model\ModelInterface;
 use ToshY\BunnyNet\Model\QueryModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class ListTickets implements ModelInterface, QueryModelInterface
 {
     /**

--- a/src/Model/Api/Base/Support/ReplyTicket.php
+++ b/src/Model/Api/Base/Support/ReplyTicket.php
@@ -13,6 +13,9 @@ use ToshY\BunnyNet\Model\AbstractParameter;
 use ToshY\BunnyNet\Model\BodyModelInterface;
 use ToshY\BunnyNet\Model\ModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class ReplyTicket implements ModelInterface, BodyModelInterface
 {
     /**

--- a/src/Model/Api/Base/User/AcceptDpa.php
+++ b/src/Model/Api/Base/User/AcceptDpa.php
@@ -8,6 +8,9 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class AcceptDpa implements ModelInterface
 {
     public function getMethod(): Method

--- a/src/Model/Api/Base/User/CloseAccount.php
+++ b/src/Model/Api/Base/User/CloseAccount.php
@@ -12,6 +12,9 @@ use ToshY\BunnyNet\Model\AbstractParameter;
 use ToshY\BunnyNet\Model\BodyModelInterface;
 use ToshY\BunnyNet\Model\ModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class CloseAccount implements ModelInterface, BodyModelInterface
 {
     /**

--- a/src/Model/Api/Base/User/DisableTwoFactorAuthentication.php
+++ b/src/Model/Api/Base/User/DisableTwoFactorAuthentication.php
@@ -12,6 +12,9 @@ use ToshY\BunnyNet\Model\AbstractParameter;
 use ToshY\BunnyNet\Model\BodyModelInterface;
 use ToshY\BunnyNet\Model\ModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class DisableTwoFactorAuthentication implements ModelInterface, BodyModelInterface
 {
     /**

--- a/src/Model/Api/Base/User/EnableTwoFactorAuthentication.php
+++ b/src/Model/Api/Base/User/EnableTwoFactorAuthentication.php
@@ -12,6 +12,9 @@ use ToshY\BunnyNet\Model\AbstractParameter;
 use ToshY\BunnyNet\Model\BodyModelInterface;
 use ToshY\BunnyNet\Model\ModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class EnableTwoFactorAuthentication implements ModelInterface, BodyModelInterface
 {
     /**

--- a/src/Model/Api/Base/User/GenerateTwoFactorAuthenticationVerification.php
+++ b/src/Model/Api/Base/User/GenerateTwoFactorAuthenticationVerification.php
@@ -8,6 +8,9 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class GenerateTwoFactorAuthenticationVerification implements ModelInterface
 {
     public function getMethod(): Method

--- a/src/Model/Api/Base/User/GetDpaDetails.php
+++ b/src/Model/Api/Base/User/GetDpaDetails.php
@@ -8,6 +8,9 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class GetDpaDetails implements ModelInterface
 {
     public function getMethod(): Method

--- a/src/Model/Api/Base/User/GetDpaDetailsHtml.php
+++ b/src/Model/Api/Base/User/GetDpaDetailsHtml.php
@@ -8,6 +8,9 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class GetDpaDetailsHtml implements ModelInterface
 {
     public function getMethod(): Method

--- a/src/Model/Api/Base/User/GetHomeFeed.php
+++ b/src/Model/Api/Base/User/GetHomeFeed.php
@@ -8,6 +8,9 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class GetHomeFeed implements ModelInterface
 {
     public function getMethod(): Method

--- a/src/Model/Api/Base/User/GetUserDetails.php
+++ b/src/Model/Api/Base/User/GetUserDetails.php
@@ -8,6 +8,9 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class GetUserDetails implements ModelInterface
 {
     public function getMethod(): Method

--- a/src/Model/Api/Base/User/GetWhatsNewItems.php
+++ b/src/Model/Api/Base/User/GetWhatsNewItems.php
@@ -8,6 +8,9 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class GetWhatsNewItems implements ModelInterface
 {
     public function getMethod(): Method

--- a/src/Model/Api/Base/User/ListCloseAccountReasons.php
+++ b/src/Model/Api/Base/User/ListCloseAccountReasons.php
@@ -8,6 +8,9 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class ListCloseAccountReasons implements ModelInterface
 {
     public function getMethod(): Method

--- a/src/Model/Api/Base/User/ListNotifications.php
+++ b/src/Model/Api/Base/User/ListNotifications.php
@@ -8,6 +8,9 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class ListNotifications implements ModelInterface
 {
     public function getMethod(): Method

--- a/src/Model/Api/Base/User/ResendEmailConfirmation.php
+++ b/src/Model/Api/Base/User/ResendEmailConfirmation.php
@@ -7,6 +7,9 @@ namespace ToshY\BunnyNet\Model\Api\Base\User;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class ResendEmailConfirmation implements ModelInterface
 {
     public function getMethod(): Method

--- a/src/Model/Api/Base/User/ResetApiKey.php
+++ b/src/Model/Api/Base/User/ResetApiKey.php
@@ -7,6 +7,9 @@ namespace ToshY\BunnyNet\Model\Api\Base\User;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class ResetApiKey implements ModelInterface
 {
     public function getMethod(): Method

--- a/src/Model/Api/Base/User/ResetWhatsNew.php
+++ b/src/Model/Api/Base/User/ResetWhatsNew.php
@@ -7,6 +7,9 @@ namespace ToshY\BunnyNet\Model\Api\Base\User;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class ResetWhatsNew implements ModelInterface
 {
     public function getMethod(): Method

--- a/src/Model/Api/Base/User/SetNotificationsOpened.php
+++ b/src/Model/Api/Base/User/SetNotificationsOpened.php
@@ -7,6 +7,9 @@ namespace ToshY\BunnyNet\Model\Api\Base\User;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class SetNotificationsOpened implements ModelInterface
 {
     public function getMethod(): Method

--- a/src/Model/Api/Base/User/UpdateUserDetails.php
+++ b/src/Model/Api/Base/User/UpdateUserDetails.php
@@ -12,6 +12,9 @@ use ToshY\BunnyNet\Model\AbstractParameter;
 use ToshY\BunnyNet\Model\BodyModelInterface;
 use ToshY\BunnyNet\Model\ModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class UpdateUserDetails implements ModelInterface, BodyModelInterface
 {
     /**

--- a/src/Model/Api/Base/User/VerifyTwoFactorAuthenticationCode.php
+++ b/src/Model/Api/Base/User/VerifyTwoFactorAuthenticationCode.php
@@ -12,6 +12,9 @@ use ToshY\BunnyNet\Model\AbstractParameter;
 use ToshY\BunnyNet\Model\BodyModelInterface;
 use ToshY\BunnyNet\Model\ModelInterface;
 
+/**
+ * @note no longer in OpenAPI spec
+ */
 class VerifyTwoFactorAuthenticationCode implements ModelInterface, BodyModelInterface
 {
     /**


### PR DESCRIPTION
Fixes https://github.com/ToshY/BunnyNet-PHP/pull/176#issuecomment-3201879706.

---

Due to changes in the OpenAPI specs, some endpoints are no longer documented but will still be available indefinitely (according to the Bunny.net support team).

These changes make sure that the models that now are no longer documented are still being kept by the generator.