### PR TITLE
Regenerated models based on rollback of OpenAPI specs

### DIFF
--- a/generator/Command/generate-maps.php
+++ b/generator/Command/generate-maps.php
@@ -40,6 +40,21 @@ foreach ($manifests as $file) {
         ),
     };
 
+    $ignoreEndpoints = match ($key) {
+        \ToshY\BunnyNet\Enum\Generator::BASE->value => [
+            /* Changed to EdgeScripting */
+            '/compute/script',
+            '/compute/script/{id}',
+            '/compute/script/{id}/code',
+            '/compute/script/{id}/releases',
+            '/compute/script/{id}/publish',
+            '/compute/script/{id}/publish/{uuid}',
+            '/compute/script/{id}/variables/add',
+            '/compute/script/{id}/variables/{variableId}',
+        ],
+        default => [],
+    };
+
     // Endpoints that are still available to use but no longer in the OpenAPI specs
     $keepUndocumentedEndpoints = match ($key) {
         \ToshY\BunnyNet\Enum\Generator::BASE->value => EndpointEdgeCases::BASE_API_UNDOCUMENTED_IN_OPEN_API_SPECS,
@@ -51,7 +66,7 @@ foreach ($manifests as $file) {
         'modelDirectory' => $modelInputDirectory . '/' . $key,
         'mappingClassName' => $key,
         'outputDirectory' => $outputDirectory,
-        'ignoreEndpoints' => [],
+        'ignoreEndpoints' => $ignoreEndpoints,
         'keepUndocumentedEndpoints' => $keepUndocumentedEndpoints,
     ];
 }

--- a/generator/Generator/ModelGenerator.php
+++ b/generator/Generator/ModelGenerator.php
@@ -137,6 +137,10 @@ class ModelGenerator
                     );
 
                     [$newNamespaceDirectory, $className] = $this->getNamespaceFromPath($path, $httpMethod);
+                    if (empty($className) === true) {
+                        continue;
+                    }
+
                     $newNamespace = $this->baseNamespace . '\\' . $newNamespaceDirectory;
                     $endpointClass = $newNamespace . '\\' . $className;
                 } else {
@@ -298,7 +302,7 @@ class ModelGenerator
 
             // Replacements for model validation strategies; should normally not be needed.
             if (empty($this->validationReplacements[$fqcn]) === false) {
-                $validationStrategyInfo['modelValidationStrategy'] = $this->validationReplacements[$subClassName];
+                $validationStrategyInfo['modelValidationStrategy'] = $this->validationReplacements[$fqcn];
             }
 
             $alias = null;
@@ -1133,7 +1137,7 @@ class ModelGenerator
             if (empty($specData['summary']) === false) {
                 $class = ClassUtils::toPascalCase($specData['summary']);
             } else {
-                // This likely won't happen
+                // This likely won't happen... unless for deprecated/no longer supported endpoints like /compute/script
                 $this->logger::print("* WARNING: Path '$path' does not have a summary to use for class name\n");
             }
         }

--- a/generator/Map/Base.php
+++ b/generator/Map/Base.php
@@ -42,9 +42,9 @@ use ToshY\BunnyNet\Model\Api\Base\DnsZone\RecheckDnsConfiguration;
 use ToshY\BunnyNet\Model\Api\Base\DnsZone\UpdateDnsRecord;
 use ToshY\BunnyNet\Model\Api\Base\DnsZone\UpdateDnsZone;
 use ToshY\BunnyNet\Model\Api\Base\DrmCertificate\ListDrmCertificates;
-use ToshY\BunnyNet\Model\Api\Base\PullZone\AddAllowedReferer;
+use ToshY\BunnyNet\Model\Api\Base\PullZone\AddAllowedReferer as PullZoneAddAllowedReferer;
 use ToshY\BunnyNet\Model\Api\Base\PullZone\AddBlockedIp;
-use ToshY\BunnyNet\Model\Api\Base\PullZone\AddBlockedReferer;
+use ToshY\BunnyNet\Model\Api\Base\PullZone\AddBlockedReferer as PullZoneAddBlockedReferer;
 use ToshY\BunnyNet\Model\Api\Base\PullZone\AddCustomCertificate;
 use ToshY\BunnyNet\Model\Api\Base\PullZone\AddCustomHostname;
 use ToshY\BunnyNet\Model\Api\Base\PullZone\AddOrUpdateEdgeRule;
@@ -59,9 +59,9 @@ use ToshY\BunnyNet\Model\Api\Base\PullZone\GetSafeHopStatistics;
 use ToshY\BunnyNet\Model\Api\Base\PullZone\ListPullZones;
 use ToshY\BunnyNet\Model\Api\Base\PullZone\LoadFreeCertificate;
 use ToshY\BunnyNet\Model\Api\Base\PullZone\PurgeCache;
-use ToshY\BunnyNet\Model\Api\Base\PullZone\RemoveAllowedReferer;
+use ToshY\BunnyNet\Model\Api\Base\PullZone\RemoveAllowedReferer as PullZoneRemoveAllowedReferer;
 use ToshY\BunnyNet\Model\Api\Base\PullZone\RemoveBlockedIp;
-use ToshY\BunnyNet\Model\Api\Base\PullZone\RemoveBlockedReferer;
+use ToshY\BunnyNet\Model\Api\Base\PullZone\RemoveBlockedReferer as PullZoneRemoveBlockedReferer;
 use ToshY\BunnyNet\Model\Api\Base\PullZone\RemoveCertificate;
 use ToshY\BunnyNet\Model\Api\Base\PullZone\RemoveCustomHostname;
 use ToshY\BunnyNet\Model\Api\Base\PullZone\ResetTokenKey;
@@ -83,8 +83,8 @@ use ToshY\BunnyNet\Model\Api\Base\StorageZone\ListStorageZones;
 use ToshY\BunnyNet\Model\Api\Base\StorageZone\ResetPassword as StorageZoneResetPassword;
 use ToshY\BunnyNet\Model\Api\Base\StorageZone\ResetReadOnlyPassword;
 use ToshY\BunnyNet\Model\Api\Base\StorageZone\UpdateStorageZone;
-use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\AddAllowedReferer as StreamVideoLibraryAddAllowedReferer;
-use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\AddBlockedReferer as StreamVideoLibraryAddBlockedReferer;
+use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\AddAllowedReferer;
+use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\AddBlockedReferer;
 use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\AddVideoLibrary;
 use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\AddWatermark;
 use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\DeleteVideoLibrary;
@@ -93,8 +93,8 @@ use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\GetDrmStatistics;
 use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\GetLanguages;
 use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\GetVideoLibrary;
 use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\ListVideoLibraries;
-use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\RemoveAllowedReferer as StreamVideoLibraryRemoveAllowedReferer;
-use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\RemoveBlockedReferer as StreamVideoLibraryRemoveBlockedReferer;
+use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\RemoveAllowedReferer;
+use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\RemoveBlockedReferer;
 use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\ResetPassword;
 use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\ResetPasswordByPathParameter;
 use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\UpdateVideoLibrary;
@@ -129,184 +129,6 @@ final class Base
 {
     /** @var array<string,array<string,class-string|null>> $endpoints */
     public static array $endpoints = [
-        '/pullzone' => [
-            'get' => ListPullZones::class,
-            'post' => AddPullZone::class,
-        ],
-        '/pullzone/{id}' => [
-            'get' => GetPullZone::class,
-            'post' => UpdatePullZone::class,
-            'delete' => DeletePullZone::class,
-        ],
-        '/pullzone/{pullZoneId}/originshield/queuestatistics' => [
-            'get' => GetOriginShieldQueueStatistics::class,
-        ],
-        '/pullzone/{pullZoneId}/safehop/statistics' => [
-            'get' => GetSafeHopStatistics::class,
-        ],
-        '/pullzone/{pullZoneId}/optimizer/statistics' => [
-            'get' => GetOptimizerStatistics::class,
-        ],
-        '/pullzone/loadFreeCertificate' => [
-            'get' => LoadFreeCertificate::class,
-        ],
-        '/pullzone/{pullZoneId}/edgerules/addOrUpdate' => [
-            'post' => AddOrUpdateEdgeRule::class,
-        ],
-        '/pullzone/{pullZoneId}/edgerules/{edgeRuleId}/setEdgeRuleEnabled' => [
-            'post' => SetEdgeRuleEnabled::class,
-        ],
-        '/pullzone/{id}/purgeCache' => [
-            'post' => PurgeCache::class,
-        ],
-        '/pullzone/checkavailability' => [
-            'post' => CheckPullZoneAvailability::class,
-        ],
-        '/pullzone/{id}/addCertificate' => [
-            'post' => AddCustomCertificate::class,
-        ],
-        '/pullzone/{id}/addHostname' => [
-            'post' => AddCustomHostname::class,
-        ],
-        '/pullzone/{id}/setForceSSL' => [
-            'post' => SetForceSsl::class,
-        ],
-        '/pullzone/{id}/resetSecurityKey' => [
-            'post' => ResetTokenKey::class,
-        ],
-        '/pullzone/{id}/addAllowedReferrer' => [
-            'post' => AddAllowedReferer::class,
-        ],
-        '/pullzone/{id}/removeAllowedReferrer' => [
-            'post' => RemoveAllowedReferer::class,
-        ],
-        '/pullzone/{id}/addBlockedReferrer' => [
-            'post' => AddBlockedReferer::class,
-        ],
-        '/pullzone/{id}/removeBlockedReferrer' => [
-            'post' => RemoveBlockedReferer::class,
-        ],
-        '/pullzone/{id}/addBlockedIp' => [
-            'post' => AddBlockedIp::class,
-        ],
-        '/pullzone/{id}/removeBlockedIp' => [
-            'post' => RemoveBlockedIp::class,
-        ],
-        '/pullzone/{pullZoneId}/edgerules/{edgeRuleId}' => [
-            'delete' => DeleteEdgeRule::class,
-        ],
-        '/pullzone/{id}/removeCertificate' => [
-            'delete' => RemoveCertificate::class,
-        ],
-        '/pullzone/{id}/removeHostname' => [
-            'delete' => RemoveCustomHostname::class,
-        ],
-        '/country' => [
-            'get' => ListCountries::class,
-        ],
-        '/dnszone' => [
-            'get' => ListDnsZones::class,
-            'post' => AddDnsZone::class,
-        ],
-        '/dnszone/{id}' => [
-            'get' => GetDnsZone::class,
-            'post' => UpdateDnsZone::class,
-            'delete' => DeleteDnsZone::class,
-        ],
-        '/dnszone/{id}/export' => [
-            'get' => ExportDnsRecords::class,
-        ],
-        '/dnszone/checkavailability' => [
-            'post' => CheckDnsZoneAvailability::class,
-        ],
-        '/dnszone/{zoneId}/records/{id}' => [
-            'post' => UpdateDnsRecord::class,
-            'delete' => DeleteDnsRecord::class,
-        ],
-        '/dnszone/{zoneId}/import' => [
-            'post' => ImportDnsRecords::class,
-        ],
-        '/dnszone/{zoneId}/records' => [
-            'put' => AddDnsRecord::class,
-        ],
-        '/region' => [
-            'get' => ListRegions::class,
-        ],
-        '/videolibrary' => [
-            'get' => ListVideoLibraries::class,
-            'post' => AddVideoLibrary::class,
-        ],
-        '/videolibrary/{id}' => [
-            'get' => GetVideoLibrary::class,
-            'post' => UpdateVideoLibrary::class,
-            'delete' => DeleteVideoLibrary::class,
-        ],
-        '/videolibrary/languages' => [
-            'get' => GetLanguages::class,
-        ],
-        '/videolibrary/resetApiKey' => [
-            'post' => ResetPassword::class,
-        ],
-        '/videolibrary/{id}/resetApiKey' => [
-            'post' => ResetPasswordByPathParameter::class,
-        ],
-        '/videolibrary/{id}/addAllowedReferrer' => [
-            'post' => StreamVideoLibraryAddAllowedReferer::class,
-        ],
-        '/videolibrary/{id}/removeAllowedReferrer' => [
-            'post' => StreamVideoLibraryRemoveAllowedReferer::class,
-        ],
-        '/videolibrary/{id}/addBlockedReferrer' => [
-            'post' => StreamVideoLibraryAddBlockedReferer::class,
-        ],
-        '/videolibrary/{id}/removeBlockedReferrer' => [
-            'post' => StreamVideoLibraryRemoveBlockedReferer::class,
-        ],
-        '/videolibrary/{id}/watermark' => [
-            'put' => AddWatermark::class,
-            'delete' => DeleteWatermark::class,
-        ],
-        '/purge' => [
-            'post' => PurgeUrl::class,
-            'get' => PurgeUrlByHeader::class,
-        ],
-        '/storagezone' => [
-            'get' => ListStorageZones::class,
-            'post' => AddStorageZone::class,
-        ],
-        '/storagezone/{id}' => [
-            'get' => GetStorageZone::class,
-            'post' => UpdateStorageZone::class,
-            'delete' => DeleteStorageZone::class,
-        ],
-        '/storagezone/checkavailability' => [
-            'post' => CheckStorageZoneAvailability::class,
-        ],
-        '/storagezone/{id}/resetPassword' => [
-            'post' => StorageZoneResetPassword::class,
-        ],
-        '/storagezone/resetReadOnlyPassword' => [
-            'post' => ResetReadOnlyPassword::class,
-        ],
-        '/statistics' => [
-            'get' => GetStatistics::class,
-        ],
-        '/storagezone/{id}/statistics' => [
-            'get' => GetStorageZoneStatistics::class,
-        ],
-        '/apikey' => [
-            'get' => ListApiKeys::class,
-        ],
-        '/videolibrary/{id}/drm/statistics' => [
-            'get' => GetDrmStatistics::class,
-        ],
-        '/dnszone/{id}/dnssec' => [
-            'post' => EnableDnssecOnDnsZone::class,
-            'delete' => DisableDnssecOnDnsZone::class,
-        ],
-        '/dnszone/{id}/statistics' => [
-            'get' => GetDnsZoneQueryStatistics::class,
-        ],
         '/abusecase' => [
             'get' => ListAbuseCases::class,
         ],
@@ -330,6 +152,12 @@ final class Base
         ],
         '/auth/jwt/refresh' => [
             'post' => RefreshJwt::class,
+        ],
+        '/search' => [
+            'get' => GlobalSearch::class,
+        ],
+        '/country' => [
+            'get' => ListCountries::class,
         ],
         '/billing' => [
             'get' => GetBillingDetails::class,
@@ -364,17 +192,8 @@ final class Base
         '/billing/applycode' => [
             'get' => ApplyPromoCode::class,
         ],
-        '/dnszone/{id}/recheckdns' => [
-            'post' => RecheckDnsConfiguration::class,
-        ],
-        '/dnszone/{id}/dismissnameservercheck' => [
-            'post' => DismissDnsConfigurationNotice::class,
-        ],
-        '/drmcertificate' => [
-            'get' => ListDrmCertificates::class,
-        ],
-        '/search' => [
-            'get' => GlobalSearch::class,
+        '/apikey' => [
+            'get' => ListApiKeys::class,
         ],
         '/support/ticket/list' => [
             'get' => ListTickets::class,
@@ -391,8 +210,189 @@ final class Base
         '/support/ticket/create' => [
             'post' => CreateTicket::class,
         ],
+        '/drmcertificate' => [
+            'get' => ListDrmCertificates::class,
+        ],
+        '/region' => [
+            'get' => ListRegions::class,
+        ],
+        '/videolibrary' => [
+            'get' => ListVideoLibraries::class,
+            'post' => AddVideoLibrary::class,
+        ],
+        '/videolibrary/{id}' => [
+            'get' => GetVideoLibrary::class,
+            'post' => UpdateVideoLibrary::class,
+            'delete' => DeleteVideoLibrary::class,
+        ],
+        '/videolibrary/languages' => [
+            'get' => GetLanguages::class,
+        ],
+        '/videolibrary/resetApiKey' => [
+            'post' => ResetPassword::class,
+        ],
+        '/videolibrary/{id}/resetApiKey' => [
+            'post' => ResetPasswordByPathParameter::class,
+        ],
+        '/videolibrary/{id}/watermark' => [
+            'put' => AddWatermark::class,
+            'delete' => DeleteWatermark::class,
+        ],
+        '/videolibrary/{id}/addAllowedReferrer' => [
+            'post' => AddAllowedReferer::class,
+        ],
+        '/videolibrary/{id}/removeAllowedReferrer' => [
+            'post' => RemoveAllowedReferer::class,
+        ],
+        '/videolibrary/{id}/addBlockedReferrer' => [
+            'post' => AddBlockedReferer::class,
+        ],
+        '/videolibrary/{id}/removeBlockedReferrer' => [
+            'post' => RemoveBlockedReferer::class,
+        ],
+        '/videolibrary/{id}/drm/statistics' => [
+            'get' => GetDrmStatistics::class,
+        ],
+        '/dnszone' => [
+            'get' => ListDnsZones::class,
+            'post' => AddDnsZone::class,
+        ],
+        '/dnszone/{id}' => [
+            'get' => GetDnsZone::class,
+            'post' => UpdateDnsZone::class,
+            'delete' => DeleteDnsZone::class,
+        ],
+        '/dnszone/{id}/dnssec' => [
+            'post' => EnableDnssecOnDnsZone::class,
+            'delete' => DisableDnssecOnDnsZone::class,
+        ],
+        '/dnszone/{id}/export' => [
+            'get' => ExportDnsRecords::class,
+        ],
+        '/dnszone/{id}/statistics' => [
+            'get' => GetDnsZoneQueryStatistics::class,
+        ],
+        '/dnszone/checkavailability' => [
+            'post' => CheckDnsZoneAvailability::class,
+        ],
+        '/dnszone/{zoneId}/records' => [
+            'put' => AddDnsRecord::class,
+        ],
+        '/dnszone/{zoneId}/records/{id}' => [
+            'post' => UpdateDnsRecord::class,
+            'delete' => DeleteDnsRecord::class,
+        ],
+        '/dnszone/{id}/recheckdns' => [
+            'post' => RecheckDnsConfiguration::class,
+        ],
+        '/dnszone/{id}/dismissnameservercheck' => [
+            'post' => DismissDnsConfigurationNotice::class,
+        ],
+        '/dnszone/{zoneId}/import' => [
+            'post' => ImportDnsRecords::class,
+        ],
+        '/pullzone' => [
+            'get' => ListPullZones::class,
+            'post' => AddPullZone::class,
+        ],
+        '/pullzone/{id}' => [
+            'get' => GetPullZone::class,
+            'post' => UpdatePullZone::class,
+            'delete' => DeletePullZone::class,
+        ],
+        '/pullzone/{pullZoneId}/edgerules/{edgeRuleId}' => [
+            'delete' => DeleteEdgeRule::class,
+        ],
+        '/pullzone/{pullZoneId}/edgerules/addOrUpdate' => [
+            'post' => AddOrUpdateEdgeRule::class,
+        ],
+        '/pullzone/{pullZoneId}/edgerules/{edgeRuleId}/setEdgeRuleEnabled' => [
+            'post' => SetEdgeRuleEnabled::class,
+        ],
+        '/pullzone/{pullZoneId}/originshield/queuestatistics' => [
+            'get' => GetOriginShieldQueueStatistics::class,
+        ],
+        '/pullzone/{pullZoneId}/safehop/statistics' => [
+            'get' => GetSafeHopStatistics::class,
+        ],
+        '/pullzone/{pullZoneId}/optimizer/statistics' => [
+            'get' => GetOptimizerStatistics::class,
+        ],
+        '/pullzone/loadFreeCertificate' => [
+            'get' => LoadFreeCertificate::class,
+        ],
+        '/pullzone/{id}/purgeCache' => [
+            'post' => PurgeCache::class,
+        ],
+        '/pullzone/checkavailability' => [
+            'post' => CheckPullZoneAvailability::class,
+        ],
+        '/pullzone/{id}/addCertificate' => [
+            'post' => AddCustomCertificate::class,
+        ],
+        '/pullzone/{id}/removeCertificate' => [
+            'delete' => RemoveCertificate::class,
+        ],
+        '/pullzone/{id}/addHostname' => [
+            'post' => AddCustomHostname::class,
+        ],
+        '/pullzone/{id}/removeHostname' => [
+            'delete' => RemoveCustomHostname::class,
+        ],
+        '/pullzone/{id}/setForceSSL' => [
+            'post' => SetForceSsl::class,
+        ],
+        '/pullzone/{id}/resetSecurityKey' => [
+            'post' => ResetTokenKey::class,
+        ],
+        '/pullzone/{id}/addAllowedReferrer' => [
+            'post' => PullZoneAddAllowedReferer::class,
+        ],
+        '/pullzone/{id}/removeAllowedReferrer' => [
+            'post' => PullZoneRemoveAllowedReferer::class,
+        ],
+        '/pullzone/{id}/addBlockedReferrer' => [
+            'post' => PullZoneAddBlockedReferer::class,
+        ],
+        '/pullzone/{id}/removeBlockedReferrer' => [
+            'post' => PullZoneRemoveBlockedReferer::class,
+        ],
+        '/pullzone/{id}/addBlockedIp' => [
+            'post' => AddBlockedIp::class,
+        ],
+        '/pullzone/{id}/removeBlockedIp' => [
+            'post' => RemoveBlockedIp::class,
+        ],
+        '/purge' => [
+            'get' => PurgeUrlByHeader::class,
+            'post' => PurgeUrl::class,
+        ],
+        '/statistics' => [
+            'get' => GetStatistics::class,
+        ],
+        '/storagezone' => [
+            'get' => ListStorageZones::class,
+            'post' => AddStorageZone::class,
+        ],
+        '/storagezone/checkavailability' => [
+            'post' => CheckStorageZoneAvailability::class,
+        ],
+        '/storagezone/{id}' => [
+            'get' => GetStorageZone::class,
+            'post' => UpdateStorageZone::class,
+            'delete' => DeleteStorageZone::class,
+        ],
         '/storagezone/{id}/connections' => [
             'get' => GetStorageZoneConnections::class,
+        ],
+        '/storagezone/{id}/statistics' => [
+            'get' => GetStorageZoneStatistics::class,
+        ],
+        '/storagezone/{id}/resetPassword' => [
+            'post' => StorageZoneResetPassword::class,
+        ],
+        '/storagezone/resetReadOnlyPassword' => [
+            'post' => ResetReadOnlyPassword::class,
         ],
         '/user/homefeed' => [
             'get' => GetHomeFeed::class,

--- a/src/Enum/Validation/Map/Base.php
+++ b/src/Enum/Validation/Map/Base.php
@@ -44,9 +44,9 @@ use ToshY\BunnyNet\Model\Api\Base\DnsZone\UpdateDnsRecord;
 use ToshY\BunnyNet\Model\Api\Base\DnsZone\UpdateDnsZone;
 use ToshY\BunnyNet\Model\Api\Base\DrmCertificate\ListDrmCertificates;
 use ToshY\BunnyNet\Model\Api\Base\Integration\GetGitHubIntegration;
-use ToshY\BunnyNet\Model\Api\Base\PullZone\AddAllowedReferer;
+use ToshY\BunnyNet\Model\Api\Base\PullZone\AddAllowedReferer as PullZoneAddAllowedReferer;
 use ToshY\BunnyNet\Model\Api\Base\PullZone\AddBlockedIp;
-use ToshY\BunnyNet\Model\Api\Base\PullZone\AddBlockedReferer;
+use ToshY\BunnyNet\Model\Api\Base\PullZone\AddBlockedReferer as PullZoneAddBlockedReferer;
 use ToshY\BunnyNet\Model\Api\Base\PullZone\AddCustomCertificate;
 use ToshY\BunnyNet\Model\Api\Base\PullZone\AddCustomHostname;
 use ToshY\BunnyNet\Model\Api\Base\PullZone\AddOrUpdateEdgeRule;
@@ -61,9 +61,9 @@ use ToshY\BunnyNet\Model\Api\Base\PullZone\GetSafeHopStatistics;
 use ToshY\BunnyNet\Model\Api\Base\PullZone\ListPullZones;
 use ToshY\BunnyNet\Model\Api\Base\PullZone\LoadFreeCertificate;
 use ToshY\BunnyNet\Model\Api\Base\PullZone\PurgeCache;
-use ToshY\BunnyNet\Model\Api\Base\PullZone\RemoveAllowedReferer;
+use ToshY\BunnyNet\Model\Api\Base\PullZone\RemoveAllowedReferer as PullZoneRemoveAllowedReferer;
 use ToshY\BunnyNet\Model\Api\Base\PullZone\RemoveBlockedIp;
-use ToshY\BunnyNet\Model\Api\Base\PullZone\RemoveBlockedReferer;
+use ToshY\BunnyNet\Model\Api\Base\PullZone\RemoveBlockedReferer as PullZoneRemoveBlockedReferer;
 use ToshY\BunnyNet\Model\Api\Base\PullZone\RemoveCertificate;
 use ToshY\BunnyNet\Model\Api\Base\PullZone\RemoveCustomHostname;
 use ToshY\BunnyNet\Model\Api\Base\PullZone\ResetTokenKey;
@@ -85,8 +85,8 @@ use ToshY\BunnyNet\Model\Api\Base\StorageZone\ListStorageZones;
 use ToshY\BunnyNet\Model\Api\Base\StorageZone\ResetPassword as StorageZoneResetPassword;
 use ToshY\BunnyNet\Model\Api\Base\StorageZone\ResetReadOnlyPassword;
 use ToshY\BunnyNet\Model\Api\Base\StorageZone\UpdateStorageZone;
-use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\AddAllowedReferer as StreamVideoLibraryAddAllowedReferer;
-use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\AddBlockedReferer as StreamVideoLibraryAddBlockedReferer;
+use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\AddAllowedReferer;
+use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\AddBlockedReferer;
 use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\AddVideoLibrary;
 use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\AddWatermark;
 use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\DeleteVideoLibrary;
@@ -95,8 +95,8 @@ use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\GetDrmStatistics;
 use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\GetLanguages;
 use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\GetVideoLibrary;
 use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\ListVideoLibraries;
-use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\RemoveAllowedReferer as StreamVideoLibraryRemoveAllowedReferer;
-use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\RemoveBlockedReferer as StreamVideoLibraryRemoveBlockedReferer;
+use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\RemoveAllowedReferer;
+use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\RemoveBlockedReferer;
 use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\ResetPassword;
 use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\ResetPasswordByPathParameter;
 use ToshY\BunnyNet\Model\Api\Base\StreamVideoLibrary\UpdateVideoLibrary;
@@ -128,75 +128,6 @@ final class Base
 {
     /** @var array<class-string,ModelValidationStrategy> $map */
     public static array $map = [
-        ListPullZones::class => ModelValidationStrategy::STRICT_QUERY,
-        AddPullZone::class => ModelValidationStrategy::STRICT_BODY,
-        GetPullZone::class => ModelValidationStrategy::STRICT_QUERY,
-        UpdatePullZone::class => ModelValidationStrategy::STRICT_BODY,
-        DeletePullZone::class => ModelValidationStrategy::NONE,
-        GetOriginShieldQueueStatistics::class => ModelValidationStrategy::STRICT_QUERY,
-        GetSafeHopStatistics::class => ModelValidationStrategy::STRICT_QUERY,
-        GetOptimizerStatistics::class => ModelValidationStrategy::STRICT_QUERY,
-        LoadFreeCertificate::class => ModelValidationStrategy::STRICT_QUERY,
-        AddOrUpdateEdgeRule::class => ModelValidationStrategy::STRICT_BODY,
-        SetEdgeRuleEnabled::class => ModelValidationStrategy::STRICT_BODY,
-        PurgeCache::class => ModelValidationStrategy::STRICT_BODY,
-        CheckPullZoneAvailability::class => ModelValidationStrategy::STRICT_BODY,
-        AddCustomCertificate::class => ModelValidationStrategy::STRICT_BODY,
-        AddCustomHostname::class => ModelValidationStrategy::STRICT_BODY,
-        SetForceSsl::class => ModelValidationStrategy::STRICT_BODY,
-        ResetTokenKey::class => ModelValidationStrategy::STRICT_BODY,
-        AddAllowedReferer::class => ModelValidationStrategy::STRICT_BODY,
-        RemoveAllowedReferer::class => ModelValidationStrategy::STRICT_BODY,
-        AddBlockedReferer::class => ModelValidationStrategy::STRICT_BODY,
-        RemoveBlockedReferer::class => ModelValidationStrategy::STRICT_BODY,
-        AddBlockedIp::class => ModelValidationStrategy::STRICT_BODY,
-        RemoveBlockedIp::class => ModelValidationStrategy::STRICT_BODY,
-        DeleteEdgeRule::class => ModelValidationStrategy::NONE,
-        RemoveCertificate::class => ModelValidationStrategy::STRICT_BODY,
-        RemoveCustomHostname::class => ModelValidationStrategy::STRICT_BODY,
-        ListCountries::class => ModelValidationStrategy::NONE,
-        ListDnsZones::class => ModelValidationStrategy::STRICT_QUERY,
-        AddDnsZone::class => ModelValidationStrategy::STRICT_BODY,
-        GetDnsZone::class => ModelValidationStrategy::NONE,
-        UpdateDnsZone::class => ModelValidationStrategy::STRICT_BODY,
-        DeleteDnsZone::class => ModelValidationStrategy::NONE,
-        ExportDnsRecords::class => ModelValidationStrategy::NONE,
-        CheckDnsZoneAvailability::class => ModelValidationStrategy::STRICT_BODY,
-        UpdateDnsRecord::class => ModelValidationStrategy::STRICT_BODY,
-        DeleteDnsRecord::class => ModelValidationStrategy::NONE,
-        ImportDnsRecords::class => ModelValidationStrategy::NONE,
-        AddDnsRecord::class => ModelValidationStrategy::STRICT_BODY,
-        ListRegions::class => ModelValidationStrategy::NONE,
-        ListVideoLibraries::class => ModelValidationStrategy::STRICT_QUERY,
-        AddVideoLibrary::class => ModelValidationStrategy::STRICT_BODY,
-        GetVideoLibrary::class => ModelValidationStrategy::NONE,
-        UpdateVideoLibrary::class => ModelValidationStrategy::STRICT_BODY,
-        DeleteVideoLibrary::class => ModelValidationStrategy::NONE,
-        GetLanguages::class => ModelValidationStrategy::NONE,
-        ResetPassword::class => ModelValidationStrategy::STRICT_QUERY,
-        ResetPasswordByPathParameter::class => ModelValidationStrategy::NONE,
-        StreamVideoLibraryAddAllowedReferer::class => ModelValidationStrategy::STRICT_BODY,
-        StreamVideoLibraryRemoveAllowedReferer::class => ModelValidationStrategy::STRICT_BODY,
-        StreamVideoLibraryAddBlockedReferer::class => ModelValidationStrategy::STRICT_BODY,
-        StreamVideoLibraryRemoveBlockedReferer::class => ModelValidationStrategy::STRICT_BODY,
-        AddWatermark::class => ModelValidationStrategy::NONE,
-        DeleteWatermark::class => ModelValidationStrategy::NONE,
-        PurgeUrl::class => ModelValidationStrategy::STRICT_QUERY,
-        ListStorageZones::class => ModelValidationStrategy::STRICT_QUERY,
-        AddStorageZone::class => ModelValidationStrategy::STRICT_BODY,
-        GetStorageZone::class => ModelValidationStrategy::NONE,
-        UpdateStorageZone::class => ModelValidationStrategy::STRICT_BODY,
-        DeleteStorageZone::class => ModelValidationStrategy::STRICT_QUERY,
-        CheckStorageZoneAvailability::class => ModelValidationStrategy::STRICT_BODY,
-        StorageZoneResetPassword::class => ModelValidationStrategy::NONE,
-        ResetReadOnlyPassword::class => ModelValidationStrategy::STRICT_QUERY,
-        GetStatistics::class => ModelValidationStrategy::STRICT_QUERY,
-        GetStorageZoneStatistics::class => ModelValidationStrategy::STRICT_QUERY,
-        ListApiKeys::class => ModelValidationStrategy::STRICT_QUERY,
-        GetDrmStatistics::class => ModelValidationStrategy::STRICT_QUERY,
-        EnableDnssecOnDnsZone::class => ModelValidationStrategy::NONE,
-        DisableDnssecOnDnsZone::class => ModelValidationStrategy::NONE,
-        GetDnsZoneQueryStatistics::class => ModelValidationStrategy::STRICT_QUERY,
         ListAbuseCases::class => ModelValidationStrategy::STRICT_QUERY,
         GetDmcaCase::class => ModelValidationStrategy::NONE,
         GetAbuseCase::class => ModelValidationStrategy::NONE,
@@ -205,6 +136,8 @@ final class Base
         CheckAbuseCase::class => ModelValidationStrategy::NONE,
         AuthJwt2fa::class => ModelValidationStrategy::STRICT_BODY,
         RefreshJwt::class => ModelValidationStrategy::NONE,
+        GlobalSearch::class => ModelValidationStrategy::STRICT_QUERY,
+        ListCountries::class => ModelValidationStrategy::NONE,
         GetBillingDetails::class => ModelValidationStrategy::NONE,
         ConfigureAutoRecharge::class => ModelValidationStrategy::STRICT_BODY,
         CreatePaymentCheckout::class => ModelValidationStrategy::STRICT_BODY,
@@ -216,16 +149,84 @@ final class Base
         GetBillingSummary::class => ModelValidationStrategy::NONE,
         GetBillingSummaryPDF::class => ModelValidationStrategy::NONE,
         ApplyPromoCode::class => ModelValidationStrategy::STRICT_QUERY,
-        RecheckDnsConfiguration::class => ModelValidationStrategy::NONE,
-        DismissDnsConfigurationNotice::class => ModelValidationStrategy::NONE,
-        ListDrmCertificates::class => ModelValidationStrategy::STRICT_QUERY,
-        PurgeUrlByHeader::class => ModelValidationStrategy::STRICT_QUERY,
+        ListApiKeys::class => ModelValidationStrategy::STRICT_QUERY,
         ListTickets::class => ModelValidationStrategy::STRICT_QUERY,
         GetTicketDetails::class => ModelValidationStrategy::NONE,
         CloseTicket::class => ModelValidationStrategy::NONE,
         ReplyTicket::class => ModelValidationStrategy::STRICT_BODY,
         CreateTicket::class => ModelValidationStrategy::STRICT_BODY,
+        ListDrmCertificates::class => ModelValidationStrategy::STRICT_QUERY,
+        ListRegions::class => ModelValidationStrategy::NONE,
+        ListVideoLibraries::class => ModelValidationStrategy::STRICT_QUERY,
+        AddVideoLibrary::class => ModelValidationStrategy::STRICT_BODY,
+        GetVideoLibrary::class => ModelValidationStrategy::NONE,
+        UpdateVideoLibrary::class => ModelValidationStrategy::STRICT_BODY,
+        DeleteVideoLibrary::class => ModelValidationStrategy::NONE,
+        GetLanguages::class => ModelValidationStrategy::NONE,
+        ResetPassword::class => ModelValidationStrategy::STRICT_QUERY,
+        ResetPasswordByPathParameter::class => ModelValidationStrategy::NONE,
+        AddWatermark::class => ModelValidationStrategy::NONE,
+        DeleteWatermark::class => ModelValidationStrategy::NONE,
+        AddAllowedReferer::class => ModelValidationStrategy::STRICT_BODY,
+        RemoveAllowedReferer::class => ModelValidationStrategy::STRICT_BODY,
+        AddBlockedReferer::class => ModelValidationStrategy::STRICT_BODY,
+        RemoveBlockedReferer::class => ModelValidationStrategy::STRICT_BODY,
+        GetDrmStatistics::class => ModelValidationStrategy::STRICT_QUERY,
+        ListDnsZones::class => ModelValidationStrategy::STRICT_QUERY,
+        AddDnsZone::class => ModelValidationStrategy::STRICT_BODY,
+        GetDnsZone::class => ModelValidationStrategy::NONE,
+        UpdateDnsZone::class => ModelValidationStrategy::STRICT_BODY,
+        DeleteDnsZone::class => ModelValidationStrategy::NONE,
+        EnableDnssecOnDnsZone::class => ModelValidationStrategy::NONE,
+        DisableDnssecOnDnsZone::class => ModelValidationStrategy::NONE,
+        ExportDnsRecords::class => ModelValidationStrategy::NONE,
+        GetDnsZoneQueryStatistics::class => ModelValidationStrategy::STRICT_QUERY,
+        CheckDnsZoneAvailability::class => ModelValidationStrategy::STRICT_BODY,
+        AddDnsRecord::class => ModelValidationStrategy::STRICT_BODY,
+        UpdateDnsRecord::class => ModelValidationStrategy::STRICT_BODY,
+        DeleteDnsRecord::class => ModelValidationStrategy::NONE,
+        RecheckDnsConfiguration::class => ModelValidationStrategy::NONE,
+        DismissDnsConfigurationNotice::class => ModelValidationStrategy::NONE,
+        ImportDnsRecords::class => ModelValidationStrategy::NONE,
+        ListPullZones::class => ModelValidationStrategy::STRICT_QUERY,
+        AddPullZone::class => ModelValidationStrategy::STRICT_BODY,
+        GetPullZone::class => ModelValidationStrategy::STRICT_QUERY,
+        UpdatePullZone::class => ModelValidationStrategy::STRICT_BODY,
+        DeletePullZone::class => ModelValidationStrategy::NONE,
+        DeleteEdgeRule::class => ModelValidationStrategy::NONE,
+        AddOrUpdateEdgeRule::class => ModelValidationStrategy::STRICT_BODY,
+        SetEdgeRuleEnabled::class => ModelValidationStrategy::STRICT_BODY,
+        GetOriginShieldQueueStatistics::class => ModelValidationStrategy::STRICT_QUERY,
+        GetSafeHopStatistics::class => ModelValidationStrategy::STRICT_QUERY,
+        GetOptimizerStatistics::class => ModelValidationStrategy::STRICT_QUERY,
+        LoadFreeCertificate::class => ModelValidationStrategy::STRICT_QUERY,
+        PurgeCache::class => ModelValidationStrategy::STRICT_BODY,
+        CheckPullZoneAvailability::class => ModelValidationStrategy::STRICT_BODY,
+        AddCustomCertificate::class => ModelValidationStrategy::STRICT_BODY,
+        RemoveCertificate::class => ModelValidationStrategy::STRICT_BODY,
+        AddCustomHostname::class => ModelValidationStrategy::STRICT_BODY,
+        RemoveCustomHostname::class => ModelValidationStrategy::STRICT_BODY,
+        SetForceSsl::class => ModelValidationStrategy::STRICT_BODY,
+        ResetTokenKey::class => ModelValidationStrategy::NONE,
+        PullZoneAddAllowedReferer::class => ModelValidationStrategy::STRICT_BODY,
+        PullZoneRemoveAllowedReferer::class => ModelValidationStrategy::STRICT_BODY,
+        PullZoneAddBlockedReferer::class => ModelValidationStrategy::STRICT_BODY,
+        PullZoneRemoveBlockedReferer::class => ModelValidationStrategy::STRICT_BODY,
+        AddBlockedIp::class => ModelValidationStrategy::STRICT_BODY,
+        RemoveBlockedIp::class => ModelValidationStrategy::STRICT_BODY,
+        PurgeUrlByHeader::class => ModelValidationStrategy::STRICT_QUERY,
+        PurgeUrl::class => ModelValidationStrategy::STRICT_QUERY,
+        GetStatistics::class => ModelValidationStrategy::STRICT_QUERY,
+        ListStorageZones::class => ModelValidationStrategy::STRICT_QUERY,
+        AddStorageZone::class => ModelValidationStrategy::STRICT_BODY,
+        CheckStorageZoneAvailability::class => ModelValidationStrategy::STRICT_BODY,
+        GetStorageZone::class => ModelValidationStrategy::NONE,
+        UpdateStorageZone::class => ModelValidationStrategy::STRICT_BODY,
+        DeleteStorageZone::class => ModelValidationStrategy::NONE,
         GetStorageZoneConnections::class => ModelValidationStrategy::NONE,
+        GetStorageZoneStatistics::class => ModelValidationStrategy::STRICT_QUERY,
+        StorageZoneResetPassword::class => ModelValidationStrategy::NONE,
+        ResetReadOnlyPassword::class => ModelValidationStrategy::STRICT_QUERY,
         GetHomeFeed::class => ModelValidationStrategy::NONE,
         ListNotifications::class => ModelValidationStrategy::NONE,
         GetUserDetails::class => ModelValidationStrategy::NONE,
@@ -245,6 +246,5 @@ final class Base
         EnableTwoFactorAuthentication::class => ModelValidationStrategy::STRICT_BODY,
         VerifyTwoFactorAuthenticationCode::class => ModelValidationStrategy::STRICT_BODY,
         GetGitHubIntegration::class => ModelValidationStrategy::NONE,
-        GlobalSearch::class => ModelValidationStrategy::STRICT_QUERY,
     ];
 }

--- a/src/Model/Api/Base/AbuseCase/CheckAbuseCase.php
+++ b/src/Model/Api/Base/AbuseCase/CheckAbuseCase.php
@@ -9,9 +9,6 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class CheckAbuseCase implements ModelInterface
 {
     /**

--- a/src/Model/Api/Base/AbuseCase/GetAbuseCase.php
+++ b/src/Model/Api/Base/AbuseCase/GetAbuseCase.php
@@ -9,9 +9,6 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class GetAbuseCase implements ModelInterface
 {
     /**

--- a/src/Model/Api/Base/AbuseCase/GetDmcaCase.php
+++ b/src/Model/Api/Base/AbuseCase/GetDmcaCase.php
@@ -9,9 +9,6 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class GetDmcaCase implements ModelInterface
 {
     /**

--- a/src/Model/Api/Base/AbuseCase/ListAbuseCases.php
+++ b/src/Model/Api/Base/AbuseCase/ListAbuseCases.php
@@ -12,9 +12,6 @@ use ToshY\BunnyNet\Model\AbstractParameter;
 use ToshY\BunnyNet\Model\ModelInterface;
 use ToshY\BunnyNet\Model\QueryModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class ListAbuseCases implements ModelInterface, QueryModelInterface
 {
     /**

--- a/src/Model/Api/Base/AbuseCase/ResolveAbuseCase.php
+++ b/src/Model/Api/Base/AbuseCase/ResolveAbuseCase.php
@@ -8,9 +8,6 @@ use ToshY\BunnyNet\Attributes\PathProperty;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class ResolveAbuseCase implements ModelInterface
 {
     /**

--- a/src/Model/Api/Base/AbuseCase/ResolveDmcaCase.php
+++ b/src/Model/Api/Base/AbuseCase/ResolveDmcaCase.php
@@ -8,9 +8,6 @@ use ToshY\BunnyNet\Attributes\PathProperty;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class ResolveDmcaCase implements ModelInterface
 {
     /**

--- a/src/Model/Api/Base/Auth/AuthJwt2fa.php
+++ b/src/Model/Api/Base/Auth/AuthJwt2fa.php
@@ -12,9 +12,6 @@ use ToshY\BunnyNet\Model\AbstractParameter;
 use ToshY\BunnyNet\Model\BodyModelInterface;
 use ToshY\BunnyNet\Model\ModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class AuthJwt2fa implements ModelInterface, BodyModelInterface
 {
     /**

--- a/src/Model/Api/Base/Auth/RefreshJwt.php
+++ b/src/Model/Api/Base/Auth/RefreshJwt.php
@@ -8,9 +8,6 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class RefreshJwt implements ModelInterface
 {
     public function getMethod(): Method

--- a/src/Model/Api/Base/Billing/ApplyPromoCode.php
+++ b/src/Model/Api/Base/Billing/ApplyPromoCode.php
@@ -12,9 +12,6 @@ use ToshY\BunnyNet\Model\AbstractParameter;
 use ToshY\BunnyNet\Model\ModelInterface;
 use ToshY\BunnyNet\Model\QueryModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class ApplyPromoCode implements ModelInterface, QueryModelInterface
 {
     /**

--- a/src/Model/Api/Base/Billing/ClaimAffiliateCredits.php
+++ b/src/Model/Api/Base/Billing/ClaimAffiliateCredits.php
@@ -8,9 +8,6 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class ClaimAffiliateCredits implements ModelInterface
 {
     public function getMethod(): Method

--- a/src/Model/Api/Base/Billing/ConfigureAutoRecharge.php
+++ b/src/Model/Api/Base/Billing/ConfigureAutoRecharge.php
@@ -12,9 +12,6 @@ use ToshY\BunnyNet\Model\AbstractParameter;
 use ToshY\BunnyNet\Model\BodyModelInterface;
 use ToshY\BunnyNet\Model\ModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class ConfigureAutoRecharge implements ModelInterface, BodyModelInterface
 {
     /**

--- a/src/Model/Api/Base/Billing/CreateCoinifyPayment.php
+++ b/src/Model/Api/Base/Billing/CreateCoinifyPayment.php
@@ -12,9 +12,6 @@ use ToshY\BunnyNet\Model\AbstractParameter;
 use ToshY\BunnyNet\Model\ModelInterface;
 use ToshY\BunnyNet\Model\QueryModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class CreateCoinifyPayment implements ModelInterface, QueryModelInterface
 {
     /**

--- a/src/Model/Api/Base/Billing/CreatePaymentCheckout.php
+++ b/src/Model/Api/Base/Billing/CreatePaymentCheckout.php
@@ -12,9 +12,6 @@ use ToshY\BunnyNet\Model\AbstractParameter;
 use ToshY\BunnyNet\Model\BodyModelInterface;
 use ToshY\BunnyNet\Model\ModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class CreatePaymentCheckout implements ModelInterface, BodyModelInterface
 {
     /**

--- a/src/Model/Api/Base/Billing/GetAffiliateDetails.php
+++ b/src/Model/Api/Base/Billing/GetAffiliateDetails.php
@@ -8,9 +8,6 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class GetAffiliateDetails implements ModelInterface
 {
     public function getMethod(): Method

--- a/src/Model/Api/Base/Billing/GetBillingDetails.php
+++ b/src/Model/Api/Base/Billing/GetBillingDetails.php
@@ -8,9 +8,6 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class GetBillingDetails implements ModelInterface
 {
     public function getMethod(): Method

--- a/src/Model/Api/Base/Billing/GetBillingSummary.php
+++ b/src/Model/Api/Base/Billing/GetBillingSummary.php
@@ -8,9 +8,6 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class GetBillingSummary implements ModelInterface
 {
     public function getMethod(): Method

--- a/src/Model/Api/Base/Billing/GetBillingSummaryPDF.php
+++ b/src/Model/Api/Base/Billing/GetBillingSummaryPDF.php
@@ -9,9 +9,6 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class GetBillingSummaryPDF implements ModelInterface
 {
     /**

--- a/src/Model/Api/Base/Billing/GetCoinifyBitcoinExchangeRate.php
+++ b/src/Model/Api/Base/Billing/GetCoinifyBitcoinExchangeRate.php
@@ -8,9 +8,6 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class GetCoinifyBitcoinExchangeRate implements ModelInterface
 {
     public function getMethod(): Method

--- a/src/Model/Api/Base/Billing/PreparePaymentAuthorization.php
+++ b/src/Model/Api/Base/Billing/PreparePaymentAuthorization.php
@@ -8,9 +8,6 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class PreparePaymentAuthorization implements ModelInterface
 {
     public function getMethod(): Method

--- a/src/Model/Api/Base/DnsZone/DismissDnsConfigurationNotice.php
+++ b/src/Model/Api/Base/DnsZone/DismissDnsConfigurationNotice.php
@@ -9,9 +9,6 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class DismissDnsConfigurationNotice implements ModelInterface
 {
     /**

--- a/src/Model/Api/Base/DnsZone/RecheckDnsConfiguration.php
+++ b/src/Model/Api/Base/DnsZone/RecheckDnsConfiguration.php
@@ -9,9 +9,6 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class RecheckDnsConfiguration implements ModelInterface
 {
     /**

--- a/src/Model/Api/Base/DrmCertificate/ListDrmCertificates.php
+++ b/src/Model/Api/Base/DrmCertificate/ListDrmCertificates.php
@@ -12,9 +12,6 @@ use ToshY\BunnyNet\Model\AbstractParameter;
 use ToshY\BunnyNet\Model\ModelInterface;
 use ToshY\BunnyNet\Model\QueryModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class ListDrmCertificates implements ModelInterface, QueryModelInterface
 {
     /**

--- a/src/Model/Api/Base/Purge/PurgeUrlByHeader.php
+++ b/src/Model/Api/Base/Purge/PurgeUrlByHeader.php
@@ -12,9 +12,6 @@ use ToshY\BunnyNet\Model\AbstractParameter;
 use ToshY\BunnyNet\Model\ModelInterface;
 use ToshY\BunnyNet\Model\QueryModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class PurgeUrlByHeader implements ModelInterface, QueryModelInterface
 {
     /**

--- a/src/Model/Api/Base/Search/GlobalSearch.php
+++ b/src/Model/Api/Base/Search/GlobalSearch.php
@@ -12,9 +12,6 @@ use ToshY\BunnyNet\Model\AbstractParameter;
 use ToshY\BunnyNet\Model\ModelInterface;
 use ToshY\BunnyNet\Model\QueryModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class GlobalSearch implements ModelInterface, QueryModelInterface
 {
     /**

--- a/src/Model/Api/Base/StorageZone/GetStorageZoneConnections.php
+++ b/src/Model/Api/Base/StorageZone/GetStorageZoneConnections.php
@@ -9,9 +9,6 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class GetStorageZoneConnections implements ModelInterface
 {
     /**

--- a/src/Model/Api/Base/Support/CloseTicket.php
+++ b/src/Model/Api/Base/Support/CloseTicket.php
@@ -8,9 +8,6 @@ use ToshY\BunnyNet\Attributes\PathProperty;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class CloseTicket implements ModelInterface
 {
     /**

--- a/src/Model/Api/Base/Support/CreateTicket.php
+++ b/src/Model/Api/Base/Support/CreateTicket.php
@@ -12,9 +12,6 @@ use ToshY\BunnyNet\Model\AbstractParameter;
 use ToshY\BunnyNet\Model\BodyModelInterface;
 use ToshY\BunnyNet\Model\ModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class CreateTicket implements ModelInterface, BodyModelInterface
 {
     /**

--- a/src/Model/Api/Base/Support/GetTicketDetails.php
+++ b/src/Model/Api/Base/Support/GetTicketDetails.php
@@ -9,9 +9,6 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class GetTicketDetails implements ModelInterface
 {
     /**

--- a/src/Model/Api/Base/Support/ListTickets.php
+++ b/src/Model/Api/Base/Support/ListTickets.php
@@ -12,9 +12,6 @@ use ToshY\BunnyNet\Model\AbstractParameter;
 use ToshY\BunnyNet\Model\ModelInterface;
 use ToshY\BunnyNet\Model\QueryModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class ListTickets implements ModelInterface, QueryModelInterface
 {
     /**

--- a/src/Model/Api/Base/Support/ReplyTicket.php
+++ b/src/Model/Api/Base/Support/ReplyTicket.php
@@ -13,9 +13,6 @@ use ToshY\BunnyNet\Model\AbstractParameter;
 use ToshY\BunnyNet\Model\BodyModelInterface;
 use ToshY\BunnyNet\Model\ModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class ReplyTicket implements ModelInterface, BodyModelInterface
 {
     /**

--- a/src/Model/Api/Base/User/AcceptDpa.php
+++ b/src/Model/Api/Base/User/AcceptDpa.php
@@ -8,9 +8,6 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class AcceptDpa implements ModelInterface
 {
     public function getMethod(): Method

--- a/src/Model/Api/Base/User/CloseAccount.php
+++ b/src/Model/Api/Base/User/CloseAccount.php
@@ -12,9 +12,6 @@ use ToshY\BunnyNet\Model\AbstractParameter;
 use ToshY\BunnyNet\Model\BodyModelInterface;
 use ToshY\BunnyNet\Model\ModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class CloseAccount implements ModelInterface, BodyModelInterface
 {
     /**

--- a/src/Model/Api/Base/User/DisableTwoFactorAuthentication.php
+++ b/src/Model/Api/Base/User/DisableTwoFactorAuthentication.php
@@ -12,9 +12,6 @@ use ToshY\BunnyNet\Model\AbstractParameter;
 use ToshY\BunnyNet\Model\BodyModelInterface;
 use ToshY\BunnyNet\Model\ModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class DisableTwoFactorAuthentication implements ModelInterface, BodyModelInterface
 {
     /**

--- a/src/Model/Api/Base/User/EnableTwoFactorAuthentication.php
+++ b/src/Model/Api/Base/User/EnableTwoFactorAuthentication.php
@@ -12,9 +12,6 @@ use ToshY\BunnyNet\Model\AbstractParameter;
 use ToshY\BunnyNet\Model\BodyModelInterface;
 use ToshY\BunnyNet\Model\ModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class EnableTwoFactorAuthentication implements ModelInterface, BodyModelInterface
 {
     /**

--- a/src/Model/Api/Base/User/GenerateTwoFactorAuthenticationVerification.php
+++ b/src/Model/Api/Base/User/GenerateTwoFactorAuthenticationVerification.php
@@ -8,9 +8,6 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class GenerateTwoFactorAuthenticationVerification implements ModelInterface
 {
     public function getMethod(): Method

--- a/src/Model/Api/Base/User/GetDpaDetails.php
+++ b/src/Model/Api/Base/User/GetDpaDetails.php
@@ -8,9 +8,6 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class GetDpaDetails implements ModelInterface
 {
     public function getMethod(): Method

--- a/src/Model/Api/Base/User/GetDpaDetailsHtml.php
+++ b/src/Model/Api/Base/User/GetDpaDetailsHtml.php
@@ -8,9 +8,6 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class GetDpaDetailsHtml implements ModelInterface
 {
     public function getMethod(): Method

--- a/src/Model/Api/Base/User/GetHomeFeed.php
+++ b/src/Model/Api/Base/User/GetHomeFeed.php
@@ -8,9 +8,6 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class GetHomeFeed implements ModelInterface
 {
     public function getMethod(): Method

--- a/src/Model/Api/Base/User/GetUserDetails.php
+++ b/src/Model/Api/Base/User/GetUserDetails.php
@@ -8,9 +8,6 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class GetUserDetails implements ModelInterface
 {
     public function getMethod(): Method

--- a/src/Model/Api/Base/User/GetWhatsNewItems.php
+++ b/src/Model/Api/Base/User/GetWhatsNewItems.php
@@ -8,9 +8,6 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class GetWhatsNewItems implements ModelInterface
 {
     public function getMethod(): Method

--- a/src/Model/Api/Base/User/ListCloseAccountReasons.php
+++ b/src/Model/Api/Base/User/ListCloseAccountReasons.php
@@ -8,9 +8,6 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class ListCloseAccountReasons implements ModelInterface
 {
     public function getMethod(): Method

--- a/src/Model/Api/Base/User/ListNotifications.php
+++ b/src/Model/Api/Base/User/ListNotifications.php
@@ -8,9 +8,6 @@ use ToshY\BunnyNet\Enum\Header;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class ListNotifications implements ModelInterface
 {
     public function getMethod(): Method

--- a/src/Model/Api/Base/User/ResendEmailConfirmation.php
+++ b/src/Model/Api/Base/User/ResendEmailConfirmation.php
@@ -7,9 +7,6 @@ namespace ToshY\BunnyNet\Model\Api\Base\User;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class ResendEmailConfirmation implements ModelInterface
 {
     public function getMethod(): Method

--- a/src/Model/Api/Base/User/ResetApiKey.php
+++ b/src/Model/Api/Base/User/ResetApiKey.php
@@ -7,9 +7,6 @@ namespace ToshY\BunnyNet\Model\Api\Base\User;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class ResetApiKey implements ModelInterface
 {
     public function getMethod(): Method

--- a/src/Model/Api/Base/User/ResetWhatsNew.php
+++ b/src/Model/Api/Base/User/ResetWhatsNew.php
@@ -7,9 +7,6 @@ namespace ToshY\BunnyNet\Model\Api\Base\User;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class ResetWhatsNew implements ModelInterface
 {
     public function getMethod(): Method

--- a/src/Model/Api/Base/User/SetNotificationsOpened.php
+++ b/src/Model/Api/Base/User/SetNotificationsOpened.php
@@ -7,9 +7,6 @@ namespace ToshY\BunnyNet\Model\Api\Base\User;
 use ToshY\BunnyNet\Enum\Method;
 use ToshY\BunnyNet\Model\ModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class SetNotificationsOpened implements ModelInterface
 {
     public function getMethod(): Method

--- a/src/Model/Api/Base/User/UpdateUserDetails.php
+++ b/src/Model/Api/Base/User/UpdateUserDetails.php
@@ -12,9 +12,6 @@ use ToshY\BunnyNet\Model\AbstractParameter;
 use ToshY\BunnyNet\Model\BodyModelInterface;
 use ToshY\BunnyNet\Model\ModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class UpdateUserDetails implements ModelInterface, BodyModelInterface
 {
     /**

--- a/src/Model/Api/Base/User/VerifyTwoFactorAuthenticationCode.php
+++ b/src/Model/Api/Base/User/VerifyTwoFactorAuthenticationCode.php
@@ -12,9 +12,6 @@ use ToshY\BunnyNet\Model\AbstractParameter;
 use ToshY\BunnyNet\Model\BodyModelInterface;
 use ToshY\BunnyNet\Model\ModelInterface;
 
-/**
- * @note no longer in OpenAPI spec
- */
 class VerifyTwoFactorAuthenticationCode implements ModelInterface, BodyModelInterface
 {
     /**


### PR DESCRIPTION
> Sidenote: the current `AddOrUpdateEdgeRule` was changed to have no strict body parameters anymore. This is a bug according to the bunny.net support team and I am awaiting it to be fixed.

_Originally posted by @ToshY in https://github.com/ToshY/BunnyNet-PHP/issues/176#issuecomment-3202125701_

---

- Due to the above bug, Bunny.net rollbacked the OpenAPI specs to the specifications that it was originally (before changing it 2-3 days ago). 
- Because it has been rollbacked, the generator has regenerated the models back based on the last specs.
- The changes made in #177 can be kept, as most likely the new OpenAPI specs will be available after issues have been resolved.
- No new release has been made yet with these changes, and I will not create a new release until the new OpenAPI specs are stable. 
- Until further notice, the latest release, [`7.3`](https://github.com/ToshY/BunnyNet-PHP/releases/tag/7.3.0), is still working as expected based on the **current** OpenAPI specs (as time of writing).


