### PR TITLE
fixed generator stream api edge case with operation id containing not allowed class name `List`

### DIFF
--- a/generator/Generator/ModelGenerator.php
+++ b/generator/Generator/ModelGenerator.php
@@ -1066,7 +1066,7 @@ class ModelGenerator
 
             $newHeadersPerResponse[$code] = self::findMimeTypeForOpenApiContentType(
                 $response->getRawSpecData(),
-                [MimeType::ALL, MimeType::JSON],
+                [MimeType::ALL, MimeType::JSON, MimeType::OCTET_STREAM],
             );
         }
 

--- a/generator/Utils/OpenApiModelUtils.php
+++ b/generator/Utils/OpenApiModelUtils.php
@@ -27,7 +27,7 @@ final class OpenApiModelUtils
      * @param array<string> $tags
      * @return string
      */
-    public static function stripTagSuffix(string $value, array $tags = ['Public', 'Index', 'Endpoint']): string
+    public static function stripTagSuffix(string $value, array $tags = ['Public', 'Index', 'Endpoint', 'List', 'Create']): string
     {
         return preg_replace(
             sprintf(


### PR DESCRIPTION
Fixes https://github.com/ToshY/BunnyNet-PHP/actions/runs/20110280570/job/57705439243#step:6:242

- Unallowed `List` generated PHP class name. Ignore both `List` and `Create`. 
- Fixes missing (new) mimetype `application/octet-stream` for `/bitrate-history` endpoint.